### PR TITLE
Additional channel/chat lifecycle events

### DIFF
--- a/libraries/botbuilder-core/botbuilder/core/teams/teams_activity_handler.py
+++ b/libraries/botbuilder-core/botbuilder/core/teams/teams_activity_handler.py
@@ -403,7 +403,7 @@ class TeamsActivityHandler(ActivityHandler):
     ):
         return
 
-    async def on_teams_team_restored(  # pyling: disable=unused-argument
+    async def on_teams_team_restored(  # pylint: disable=unused-argument
         self, team_info: TeamInfo, turn_context: TurnContext
     ):
         """

--- a/libraries/botbuilder-core/botbuilder/core/teams/teams_activity_handler.py
+++ b/libraries/botbuilder-core/botbuilder/core/teams/teams_activity_handler.py
@@ -324,8 +324,28 @@ class TeamsActivityHandler(ActivityHandler):
                     return await self.on_teams_channel_renamed(
                         channel_data.channel, channel_data.team, turn_context
                     )
+                if channel_data.event_type == "teamArchived":
+                    return await self.on_teams_team_archived(
+                        channel_data.team, turn_context
+                    )
+                if channel_data.event_type == "teamDeleted":
+                    return await self.on_teams_team_deleted(
+                        channel_data.team, turn_context
+                    )
+                if channel_data.event_type == "teamHardDeleted":
+                    return await self.on_teams_team_hard_deleted(
+                        channel_data.team, turn_context
+                    )
                 if channel_data.event_type == "teamRenamed":
                     return await self.on_teams_team_renamed_activity(
+                        channel_data.team, turn_context
+                    )
+                if channel_data.event_type == "teamRestored":
+                    return await self.on_teams_team_restored(
+                        channel_data.team, turn_context
+                    )
+                if channel_data.event_type == "teamUnarchived":
+                    return await self.on_teams_team_unarchived(
                         channel_data.team, turn_context
                     )
 
@@ -336,9 +356,79 @@ class TeamsActivityHandler(ActivityHandler):
     ):
         return
 
+    async def on_teams_team_archived(  # pylint: disable=unused-argument
+        self, team_info: TeamInfo, turn_context: TurnContext
+    ):
+        """
+        Invoked when a Team Archived event activity is received from the connector.
+        Team Archived correspond to the user archiving a team.
+
+        :param team_info: The team info object representing the team.
+        :param turn_context: A context object for this turn.
+
+        :returns: A task that represents the work queued to execute.
+        """
+        return
+
+    async def on_teams_team_deleted(  # pylint: disable=unused-argument
+        self, team_info: TeamInfo, turn_context: TurnContext
+    ):
+        """
+        Invoked when a Team Deleted event activity is received from the connector.
+        Team Deleted corresponds to the user deleting a team.
+
+        :param team_info: The team info object representing the team.
+        :param turn_context: A context object for this turn.
+
+        :returns: A task that represents the work queued to execute.
+        """
+        return
+
+    async def on_teams_team_hard_deleted(  # pylint: disable=unused-argument
+        self, team_info: TeamInfo, turn_context: TurnContext
+    ):
+        """
+        Invoked when a Team Hard Deleted event activity is received from the connector.
+        Team Hard Deleted corresponds to the user hard deleting a team.
+
+        :param team_info: The team info object representing the team.
+        :param turn_context: A context object for this turn.
+
+        :returns: A task that represents the work queued to execute.
+        """
+        return
+
     async def on_teams_team_renamed_activity(  # pylint: disable=unused-argument
         self, team_info: TeamInfo, turn_context: TurnContext
     ):
+        return
+
+    async def on_teams_team_restored(  # pyling: disable=unused-argument
+        self, team_info: TeamInfo, turn_context: TurnContext
+    ):
+        """
+        Invoked when a Team Restored event activity is received from the connector.
+        Team Restored corresponds to the user restoring a team.
+
+        :param team_info: The team info object representing the team.
+        :param turn_context: A context object for this turn.
+
+        :returns: A task that represents the work queued to execute.
+        """
+        return
+
+    async def on_teams_team_unarchived(  # pylint: disable=unused-argument
+        self, team_info: TeamInfo, turn_context: TurnContext
+    ):
+        """
+        Invoked when a Team Unarchived event activity is received from the connector.
+        Team Unarchived correspond to the user unarchiving a team.
+
+        :param team_info: The team info object representing the team.
+        :param turn_context: A context object for this turn.
+
+        :returns: A task that represents the work queued to execute.
+        """
         return
 
     async def on_teams_members_added_dispatch(  # pylint: disable=unused-argument

--- a/libraries/botbuilder-core/tests/teams/test_teams_activity_handler.py
+++ b/libraries/botbuilder-core/tests/teams/test_teams_activity_handler.py
@@ -108,11 +108,41 @@ class TestingTeamsActivityHandler(TeamsActivityHandler):
             channel_info, team_info, turn_context
         )
 
+    async def on_teams_team_archived(
+        self, team_info: TeamInfo, turn_context: TurnContext
+    ):
+        self.record.append("on_teams_team_archived")
+        return await super().on_teams_team_archived(team_info, turn_context)
+
+    async def on_teams_team_deleted(
+        self, team_info: TeamInfo, turn_context: TurnContext
+    ):
+        self.record.append("on_teams_team_deleted")
+        return await super().on_teams_team_deleted(team_info, turn_context)
+
+    async def on_teams_team_hard_deleted(
+        self, team_info: TeamInfo, turn_context: TurnContext
+    ):
+        self.record.append("on_teams_team_hard_deleted")
+        return await super().on_teams_team_hard_deleted(team_info, turn_context)
+
     async def on_teams_team_renamed_activity(
         self, team_info: TeamInfo, turn_context: TurnContext
     ):
         self.record.append("on_teams_team_renamed_activity")
         return await super().on_teams_team_renamed_activity(team_info, turn_context)
+
+    async def on_teams_team_restored(
+        self, team_info: TeamInfo, turn_context: TurnContext
+    ):
+        self.record.append("on_teams_team_restored")
+        return await super().on_teams_team_restored(team_info, turn_context)
+
+    async def on_teams_team_unarchived(
+        self, team_info: TeamInfo, turn_context: TurnContext
+    ):
+        self.record.append("on_teams_team_unarchived")
+        return await super().on_teams_team_unarchived(team_info, turn_context)
 
     async def on_invoke_activity(self, turn_context: TurnContext):
         self.record.append("on_invoke_activity")
@@ -335,6 +365,72 @@ class TestTeamsActivityHandler(aiounittest.AsyncTestCase):
         assert bot.record[0] == "on_conversation_update_activity"
         assert bot.record[1] == "on_teams_channel_deleted"
 
+    async def test_on_teams_team_archived(self):
+        # arrange
+        activity = Activity(
+            type=ActivityTypes.conversation_update,
+            channel_data={
+                "eventType": "teamArchived",
+                "team": {"id": "team_id_1", "name": "archived_team_name"},
+            },
+            channel_id=Channels.ms_teams,
+        )
+
+        turn_context = TurnContext(NotImplementedAdapter(), activity)
+
+        # Act
+        bot = TestingTeamsActivityHandler()
+        await bot.on_turn(turn_context)
+
+        # Assert
+        assert len(bot.record) == 2
+        assert bot.record[0] == "on_conversation_update_activity"
+        assert bot.record[1] == "on_teams_team_archived"
+
+    async def test_on_teams_team_deleted(self):
+        # arrange
+        activity = Activity(
+            type=ActivityTypes.conversation_update,
+            channel_data={
+                "eventType": "teamDeleted",
+                "team": {"id": "team_id_1", "name": "deleted_team_name"},
+            },
+            channel_id=Channels.ms_teams,
+        )
+
+        turn_context = TurnContext(NotImplementedAdapter(), activity)
+
+        # Act
+        bot = TestingTeamsActivityHandler()
+        await bot.on_turn(turn_context)
+
+        # Assert
+        assert len(bot.record) == 2
+        assert bot.record[0] == "on_conversation_update_activity"
+        assert bot.record[1] == "on_teams_team_deleted"
+
+    async def test_on_teams_team_hard_deleted(self):
+        # arrange
+        activity = Activity(
+            type=ActivityTypes.conversation_update,
+            channel_data={
+                "eventType": "teamHardDeleted",
+                "team": {"id": "team_id_1", "name": "hard_deleted_team_name"},
+            },
+            channel_id=Channels.ms_teams,
+        )
+
+        turn_context = TurnContext(NotImplementedAdapter(), activity)
+
+        # Act
+        bot = TestingTeamsActivityHandler()
+        await bot.on_turn(turn_context)
+
+        # Assert
+        assert len(bot.record) == 2
+        assert bot.record[0] == "on_conversation_update_activity"
+        assert bot.record[1] == "on_teams_team_hard_deleted"
+
     async def test_on_teams_team_renamed_activity(self):
         # arrange
         activity = Activity(
@@ -356,6 +452,50 @@ class TestTeamsActivityHandler(aiounittest.AsyncTestCase):
         assert len(bot.record) == 2
         assert bot.record[0] == "on_conversation_update_activity"
         assert bot.record[1] == "on_teams_team_renamed_activity"
+
+    async def test_on_teams_team_restored(self):
+        # arrange
+        activity = Activity(
+            type=ActivityTypes.conversation_update,
+            channel_data={
+                "eventType": "teamRestored",
+                "team": {"id": "team_id_1", "name": "restored_team_name"},
+            },
+            channel_id=Channels.ms_teams,
+        )
+
+        turn_context = TurnContext(NotImplementedAdapter(), activity)
+
+        # Act
+        bot = TestingTeamsActivityHandler()
+        await bot.on_turn(turn_context)
+
+        # Assert
+        assert len(bot.record) == 2
+        assert bot.record[0] == "on_conversation_update_activity"
+        assert bot.record[1] == "on_teams_team_restored"
+
+    async def test_on_teams_team_unarchived(self):
+        # arrange
+        activity = Activity(
+            type=ActivityTypes.conversation_update,
+            channel_data={
+                "eventType": "teamUnarchived",
+                "team": {"id": "team_id_1", "name": "unarchived_team_name"},
+            },
+            channel_id=Channels.ms_teams,
+        )
+
+        turn_context = TurnContext(NotImplementedAdapter(), activity)
+
+        # Act
+        bot = TestingTeamsActivityHandler()
+        await bot.on_turn(turn_context)
+
+        # Assert
+        assert len(bot.record) == 2
+        assert bot.record[0] == "on_conversation_update_activity"
+        assert bot.record[1] == "on_teams_team_unarchived"
 
     async def test_on_teams_members_added_activity(self):
         # arrange


### PR DESCRIPTION
Fixes # 1143

## Description
- Add the following events to the [TeamsActivityHandler](https://github.com/microsoft/botbuilder-python/blob/master/libraries/botbuilder-core/botbuilder/core/teams/teams_activity_handler.py) class.
  - teamArchived
  - teamDeleted
  - teamHardDeleted
  - teamRestored
  - teamUnarchived

**Note:** These changes can't be tested using MS-Teams until the implementation to use these events is done.
## Specific Changes
- Updated [teams_activity_handler.py](https://github.com/microsoft/botbuilder-python/blob/master/libraries/botbuilder-core/botbuilder/core/teams/teams_activity_handler.py) class to add.
  - _on_teams_team_archived_ method.
  - _on_teams_team_deleted_ method.
  - _on_teams_team_hard_deleted_ method.
  - _on_teams_team_restored_ method.
  - _on_teams_team_unarchived_ method.
- Updated event validations to add ` teamArchived` , ` teamDeleted` , ` teamHardDeleted` , ` teamRestored`  and ` teamUnarchived` , calling the previous methods corresponding to each case.
- Updated [test_teams_activity_handler.py](https://github.com/microsoft/botbuilder-python/blob/master/libraries/botbuilder-core/tests/teams/test_teams_activity_handler.py) class to add the unit tests for the previous methods.

## Testing
You can see the added tests running in the following image.
![image](https://user-images.githubusercontent.com/38112957/86277240-c3aec000-bbac-11ea-8baf-e0cc529498e1.png)
