### PR TITLE
Update telemetry logger to include attachments

### DIFF
--- a/libraries/botbuilder-core/botbuilder/core/telemetry_constants.py
+++ b/libraries/botbuilder-core/botbuilder/core/telemetry_constants.py
@@ -5,6 +5,7 @@
 class TelemetryConstants:
     """Telemetry logger property names."""
 
+    ATTACHMENTS_PROPERTY: str = "attachments"
     CHANNEL_ID_PROPERTY: str = "channelId"
     CONVERSATION_ID_PROPERTY: str = "conversationId"
     CONVERSATION_NAME_PROPERTY: str = "conversationName"

--- a/libraries/botbuilder-core/botbuilder/core/telemetry_logger_middleware.py
+++ b/libraries/botbuilder-core/botbuilder/core/telemetry_logger_middleware.py
@@ -211,6 +211,8 @@ class TelemetryLoggerMiddleware(Middleware):
 
         # Use the LogPersonalInformation flag to toggle logging PII data, text and user name are common examples
         if self.log_personal_information:
+            if activity.attachments and activity.attachments.strip():
+                properties[TelemetryConstants.ATTACHMENTS_PROPERTY] = activity.attachments
             if activity.from_property.name and activity.from_property.name.strip():
                 properties[
                     TelemetryConstants.FROM_NAME_PROPERTY

--- a/libraries/botbuilder-core/botbuilder/core/telemetry_logger_middleware.py
+++ b/libraries/botbuilder-core/botbuilder/core/telemetry_logger_middleware.py
@@ -212,7 +212,9 @@ class TelemetryLoggerMiddleware(Middleware):
         # Use the LogPersonalInformation flag to toggle logging PII data, text and user name are common examples
         if self.log_personal_information:
             if activity.attachments and activity.attachments.strip():
-                properties[TelemetryConstants.ATTACHMENTS_PROPERTY] = activity.attachments
+                properties[
+                    TelemetryConstants.ATTACHMENTS_PROPERTY
+                ] = activity.attachments
             if activity.from_property.name and activity.from_property.name.strip():
                 properties[
                     TelemetryConstants.FROM_NAME_PROPERTY


### PR DESCRIPTION
Fixes # 940

## Description
Logs attachments on outgoing activities in telemetry, if the LogPersonalInformation flag is set to true.

## Specific Changes
- Added `ATTACHMENTS_PROPERTY` to `telemetry_constants.py`
- Added validation to log the attachment property in `telemetry_logger_middleware.py`