### PR TITLE
[#631][PORT] [Slack Adapters] Add Slack Functional Test

### DIFF
--- a/libraries/functional-tests/requirements.txt
+++ b/libraries/functional-tests/requirements.txt
@@ -1,0 +1,2 @@
+requests==2.23.0
+aiounittest==1.3.0

--- a/libraries/functional-tests/slacktestbot/app.py
+++ b/libraries/functional-tests/slacktestbot/app.py
@@ -1,0 +1,78 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import sys
+import traceback
+from datetime import datetime
+
+from aiohttp import web
+from aiohttp.web import Request, Response
+from botbuilder.adapters.slack import SlackAdapterOptions
+from botbuilder.adapters.slack import SlackAdapter
+from botbuilder.adapters.slack import SlackClient
+from botbuilder.core import TurnContext
+from botbuilder.core.integration import aiohttp_error_middleware
+from botbuilder.schema import Activity, ActivityTypes
+
+from bots import EchoBot
+from config import DefaultConfig
+
+CONFIG = DefaultConfig()
+
+# Create adapter.
+SLACK_OPTIONS = SlackAdapterOptions(
+    CONFIG.SLACK_VERIFICATION_TOKEN,
+    CONFIG.SLACK_BOT_TOKEN,
+    CONFIG.SLACK_CLIENT_SIGNING_SECRET,
+)
+SLACK_CLIENT = SlackClient(SLACK_OPTIONS)
+ADAPTER = SlackAdapter(SLACK_CLIENT)
+
+
+# Catch-all for errors.
+async def on_error(context: TurnContext, error: Exception):
+    # This check writes out errors to console log .vs. app insights.
+    # NOTE: In production environment, you should consider logging this to Azure
+    #       application insights.
+    print(f"\n [on_turn_error] unhandled error: {error}", file=sys.stderr)
+    traceback.print_exc()
+
+    # Send a message to the user
+    await context.send_activity("The bot encountered an error or bug.")
+    await context.send_activity(
+        "To continue to run this bot, please fix the bot source code."
+    )
+    # Send a trace activity if we're talking to the Bot Framework Emulator
+    if context.activity.channel_id == "emulator":
+        # Create a trace activity that contains the error object
+        trace_activity = Activity(
+            label="TurnError",
+            name="on_turn_error Trace",
+            timestamp=datetime.utcnow(),
+            type=ActivityTypes.trace,
+            value=f"{error}",
+            value_type="https://www.botframework.com/schemas/error",
+        )
+        # Send a trace activity, which will be displayed in Bot Framework Emulator
+        await context.send_activity(trace_activity)
+
+
+ADAPTER.on_turn_error = on_error
+
+# Create the Bot
+BOT = EchoBot()
+
+
+# Listen for incoming requests on /api/messages
+async def messages(req: Request) -> Response:
+    return await ADAPTER.process(req, BOT.on_turn)
+
+
+APP = web.Application(middlewares=[aiohttp_error_middleware])
+APP.router.add_post("/api/messages", messages)
+
+if __name__ == "__main__":
+    try:
+        web.run_app(APP, host="localhost", port=CONFIG.PORT)
+    except Exception as error:
+        raise error

--- a/libraries/functional-tests/slacktestbot/bots/__init__.py
+++ b/libraries/functional-tests/slacktestbot/bots/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from .echo_bot import EchoBot
+
+__all__ = ["EchoBot"]

--- a/libraries/functional-tests/slacktestbot/bots/echo_bot.py
+++ b/libraries/functional-tests/slacktestbot/bots/echo_bot.py
@@ -1,0 +1,54 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import json
+import os
+
+from botbuilder.adapters.slack import SlackRequestBody, SlackEvent
+from botbuilder.core import ActivityHandler, MessageFactory, TurnContext
+from botbuilder.schema import ChannelAccount, Attachment
+
+
+class EchoBot(ActivityHandler):
+    async def on_members_added_activity(
+        self, members_added: [ChannelAccount], turn_context: TurnContext
+    ):
+        for member in members_added:
+            if member.id != turn_context.activity.recipient.id:
+                await turn_context.send_activity("Hello and welcome!")
+
+    async def on_message_activity(self, turn_context: TurnContext):
+        return await turn_context.send_activity(
+            MessageFactory.text(f"Echo: {turn_context.activity.text}")
+        )
+
+    async def on_event_activity(self, turn_context: TurnContext):
+        body = turn_context.activity.channel_data
+        if not body:
+            return
+
+        if isinstance(body, SlackRequestBody) and body.command == "/test":
+            interactive_message = MessageFactory.attachment(
+                self.__create_interactive_message(
+                    os.path.join(os.getcwd(), "./resources/InteractiveMessage.json")
+                )
+            )
+            await turn_context.send_activity(interactive_message)
+
+        if isinstance(body, SlackEvent):
+            if body.subtype == "file_share":
+                await turn_context.send_activity("Echo: I received and attachment")
+            elif body.message and body.message.attachments:
+                await turn_context.send_activity("Echo: I received a link share")
+
+    def __create_interactive_message(self, file_path: str) -> Attachment:
+        # interactive_message_json = open(file_path).read()
+        # adaptive_card_attachment = json.loads(interactive_message_json, cls=Block)
+        with open(file_path, "rb") as in_file:
+            adaptive_card_attachment = json.load(in_file)
+
+        return Attachment(
+            content=adaptive_card_attachment,
+            content_type="application/json",
+            name="blocks",
+        )

--- a/libraries/functional-tests/slacktestbot/bots/echo_bot.py
+++ b/libraries/functional-tests/slacktestbot/bots/echo_bot.py
@@ -42,8 +42,6 @@ class EchoBot(ActivityHandler):
                 await turn_context.send_activity("Echo: I received a link share")
 
     def __create_interactive_message(self, file_path: str) -> Attachment:
-        # interactive_message_json = open(file_path).read()
-        # adaptive_card_attachment = json.loads(interactive_message_json, cls=Block)
         with open(file_path, "rb") as in_file:
             adaptive_card_attachment = json.load(in_file)
 

--- a/libraries/functional-tests/slacktestbot/config.py
+++ b/libraries/functional-tests/slacktestbot/config.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import os
+
+
+class DefaultConfig:
+    """ Bot Configuration """
+
+    PORT = 3978
+
+    SLACK_VERIFICATION_TOKEN = os.environ.get(
+        "SlackVerificationToken", ""
+    )
+    SLACK_BOT_TOKEN = os.environ.get(
+        "SlackBotToken", ""
+    )
+    SLACK_CLIENT_SIGNING_SECRET = os.environ.get(
+        "SlackClientSigningSecret", ""
+    )

--- a/libraries/functional-tests/slacktestbot/deploymentTemplates/template-with-new-rg.json
+++ b/libraries/functional-tests/slacktestbot/deploymentTemplates/template-with-new-rg.json
@@ -1,0 +1,297 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+       "groupLocation": {
+           "type": "string",
+           "metadata": {
+               "description": "Specifies the location of the Resource Group."
+           }
+       },
+       "groupName": {
+           "type": "string",
+           "metadata": {
+               "description": "Specifies the name of the Resource Group."
+           }
+       },
+       "appId": {
+           "type": "string",
+           "metadata": {
+               "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+           }
+       },
+       "appSecret": {
+           "type": "string",
+           "metadata": {
+               "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+           }
+       },
+       "botId": {
+           "type": "string",
+           "metadata": {
+               "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
+           }
+       },
+       "botSku": {
+           "type": "string",
+           "metadata": {
+               "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+           }
+       },
+       "newAppServicePlanName": {
+           "type": "string",
+           "metadata": {
+               "description": "The name of the App Service Plan."
+           }
+       },
+       "newAppServicePlanSku": {
+           "type": "object",
+           "defaultValue": {
+               "name": "S1",
+               "tier": "Standard",
+               "size": "S1",
+               "family": "S",
+               "capacity": 1
+           },
+           "metadata": {
+               "description": "The SKU of the App Service Plan. Defaults to Standard values."
+           }
+       },
+       "newAppServicePlanLocation": {
+           "type": "string",
+           "metadata": {
+               "description": "The location of the App Service Plan. Defaults to \"westus\"."
+           }
+       },
+       "newWebAppName": {
+           "type": "string",
+           "defaultValue": "",
+           "metadata": {
+               "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
+           }
+       },
+       "slackVerificationToken": {
+           "type": "string",
+           "defaultValue": "",
+           "metadata": {
+               "description": "The slack verification token, taken from the Slack page after create an app."
+           }
+       },
+       "slackBotToken": {
+           "type": "string",
+           "defaultValue": "",
+           "metadata": {
+               "description": "The slack bot token, taken from the Slack page after create an app."
+           }
+       },
+       "slackClientSigningSecret": {
+           "type": "string",
+           "defaultValue": "",
+           "metadata": {
+               "description": "The slack client signing secret, taken from the Slack page after create an app."
+           }
+       }
+   },
+   "variables": {
+       "appServicePlanName": "[parameters('newAppServicePlanName')]",
+       "resourcesLocation": "[parameters('newAppServicePlanLocation')]",
+       "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
+       "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
+       "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+       "publishingUsername": "[concat('$', parameters('newWebAppName'))]",
+       "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
+   },
+   "resources": [
+       {
+           "name": "[parameters('groupName')]",
+           "type": "Microsoft.Resources/resourceGroups",
+           "apiVersion": "2018-05-01",
+           "location": "[parameters('groupLocation')]",
+           "properties": {}
+       },
+       {
+           "type": "Microsoft.Resources/deployments",
+           "apiVersion": "2018-05-01",
+           "name": "storageDeployment",
+           "resourceGroup": "[parameters('groupName')]",
+           "dependsOn": [
+               "[resourceId('Microsoft.Resources/resourceGroups/', parameters('groupName'))]"
+           ],
+           "properties": {
+               "mode": "Incremental",
+               "template": {
+                   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                   "contentVersion": "1.0.0.0",
+                   "parameters": {},
+                   "variables": {},
+                   "resources": [
+                       {
+                           "comments": "Create a new Linux App Service Plan if no existing App Service Plan name was passed in.",
+                           "type": "Microsoft.Web/serverfarms",
+                           "name": "[variables('appServicePlanName')]",
+                           "apiVersion": "2018-02-01",
+                           "location": "[variables('resourcesLocation')]",
+                           "sku": "[parameters('newAppServicePlanSku')]",
+                           "kind": "linux",
+                           "properties": {
+                               "name": "[variables('appServicePlanName')]",
+                               "perSiteScaling": false,
+                               "reserved": true,
+                               "targetWorkerCount": 0,
+                               "targetWorkerSizeId": 0
+                           }
+                       },
+                       {
+                           "comments": "Create a Web App using a Linux App Service Plan",
+                           "type": "Microsoft.Web/sites",
+                           "apiVersion": "2015-08-01",
+                           "location": "[variables('resourcesLocation')]",
+                           "kind": "app,linux",
+                           "dependsOn": [
+                               "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
+                           ],
+                           "name": "[variables('webAppName')]",
+                           "properties": {
+                               "name": "[variables('webAppName')]",
+                               "hostNameSslStates": [
+                                   {
+                                       "name": "[concat(parameters('newWebAppName'), '.azurewebsites.net')]",
+                                       "sslState": "Disabled",
+                                       "hostType": "Standard"
+                                   },
+                                   {
+                                       "name": "[concat(parameters('newWebAppName'), '.scm.azurewebsites.net')]",
+                                       "sslState": "Disabled",
+                                       "hostType": "Repository"
+                                   }
+                               ],
+                               "serverFarmId": "[variables('appServicePlanName')]",
+                               "siteConfig": {
+                                   "appSettings": [
+                                       {
+                                           "name": "SCM_DO_BUILD_DURING_DEPLOYMENT",
+                                           "value": "true"
+                                       },
+                                       {
+                                           "name": "MicrosoftAppId",
+                                           "value": "[parameters('appId')]"
+                                       },
+                                       {
+                                           "name": "MicrosoftAppPassword",
+                                           "value": "[parameters('appSecret')]"
+                                       },
+                                       {
+                                          "name": "SlackVerificationToken",
+                                          "value": "[parameters('slackVerificationToken')]"
+                                       },
+                                       {
+                                          "name": "SlackBotToken",
+                                          "value": "[parameters('slackBotToken')]"
+                                       },
+                                       {
+                                          "name": "SlackClientSigningSecret",
+                                          "value": "[parameters('slackClientSigningSecret')]"
+                                       }
+                                   ],
+                                   "cors": {
+                                       "allowedOrigins": [
+                                           "https://botservice.hosting.portal.azure.net",
+                                           "https://hosting.onecloud.azure-test.net/"
+                                       ]
+                                   }
+                               }
+                           }
+                       },
+                       {
+                           "type": "Microsoft.Web/sites/config",
+                           "apiVersion": "2016-08-01",
+                           "name": "[concat(variables('webAppName'), '/web')]",
+                           "location": "[variables('resourcesLocation')]",
+                           "dependsOn": [
+                               "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
+                           ],
+                           "properties": {
+                               "numberOfWorkers": 1,
+                               "defaultDocuments": [
+                                   "Default.htm",
+                                   "Default.html",
+                                   "Default.asp",
+                                   "index.htm",
+                                   "index.html",
+                                   "iisstart.htm",
+                                   "default.aspx",
+                                   "index.php",
+                                   "hostingstart.html"
+                               ],
+                               "netFrameworkVersion": "v4.0",
+                               "phpVersion": "",
+                               "pythonVersion": "",
+                               "nodeVersion": "",
+                               "linuxFxVersion": "PYTHON|3.7",
+                               "requestTracingEnabled": false,
+                               "remoteDebuggingEnabled": false,
+                               "remoteDebuggingVersion": "VS2017",
+                               "httpLoggingEnabled": true,
+                               "logsDirectorySizeLimit": 35,
+                               "detailedErrorLoggingEnabled": false,
+                               "publishingUsername": "[variables('publishingUsername')]",
+                               "scmType": "None",
+                               "use32BitWorkerProcess": true,
+                               "webSocketsEnabled": false,
+                               "alwaysOn": false,
+                               "appCommandLine": "gunicorn --bind 0.0.0.0 --worker-class aiohttp.worker.GunicornWebWorker --timeout 600 app:APP",
+                               "managedPipelineMode": "Integrated",
+                               "virtualApplications": [
+                                   {
+                                       "virtualPath": "/",
+                                       "physicalPath": "site\\wwwroot",
+                                       "preloadEnabled": false,
+                                       "virtualDirectories": null
+                                   }
+                               ],
+                               "winAuthAdminState": 0,
+                               "winAuthTenantState": 0,
+                               "customAppPoolIdentityAdminState": false,
+                               "customAppPoolIdentityTenantState": false,
+                               "loadBalancing": "LeastRequests",
+                               "routingRules": [],
+                               "experiments": {
+                                   "rampUpRules": []
+                               },
+                               "autoHealEnabled": false,
+                               "vnetName": "",
+                               "minTlsVersion": "1.2",
+                               "ftpsState": "AllAllowed",
+                               "reservedInstanceCount": 0
+                           }
+                       },
+                       {
+                           "apiVersion": "2017-12-01",
+                           "type": "Microsoft.BotService/botServices",
+                           "name": "[parameters('botId')]",
+                           "location": "global",
+                           "kind": "bot",
+                           "sku": {
+                               "name": "[parameters('botSku')]"
+                           },
+                           "properties": {
+                               "name": "[parameters('botId')]",
+                               "displayName": "[parameters('botId')]",
+                               "endpoint": "[variables('botEndpoint')]",
+                               "msaAppId": "[parameters('appId')]",
+                               "developerAppInsightsApplicationId": null,
+                               "developerAppInsightKey": null,
+                               "publishingCredentials": null,
+                               "storageResourceId": null
+                           },
+                           "dependsOn": [
+                               "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
+                           ]
+                       }
+                   ],
+                   "outputs": {}
+               }
+           }
+       }
+   ]
+}

--- a/libraries/functional-tests/slacktestbot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/libraries/functional-tests/slacktestbot/deploymentTemplates/template-with-preexisting-rg.json
@@ -1,0 +1,275 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+      "appId": {
+         "type": "string",
+         "metadata": {
+            "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+         }
+      },
+      "appSecret": {
+         "type": "string",
+         "metadata": {
+            "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+         }
+      },
+      "botId": {
+         "type": "string",
+         "metadata": {
+            "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
+         }
+      },
+      "botSku": {
+         "defaultValue": "F0",
+         "type": "string",
+         "metadata": {
+            "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+         }
+      },
+      "newAppServicePlanName": {
+         "type": "string",
+         "defaultValue": "",
+         "metadata": {
+            "description": "The name of the new App Service Plan."
+         }
+      },
+      "newAppServicePlanSku": {
+         "type": "object",
+         "defaultValue": {
+            "name": "S1",
+            "tier": "Standard",
+            "size": "S1",
+            "family": "S",
+            "capacity": 1
+         },
+         "metadata": {
+            "description": "The SKU of the App Service Plan. Defaults to Standard values."
+         }
+      },
+      "appServicePlanLocation": {
+         "type": "string",
+         "metadata": {
+            "description": "The location of the App Service Plan."
+         }
+      },
+      "existingAppServicePlan": {
+         "type": "string",
+         "defaultValue": "",
+         "metadata": {
+            "description": "Name of the existing App Service Plan used to create the Web App for the bot."
+         }
+      },
+      "newWebAppName": {
+         "type": "string",
+         "defaultValue": "",
+         "metadata": {
+            "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
+         }
+      },
+      "slackVerificationToken": {
+         "type": "string",
+         "defaultValue": "",
+         "metadata": {
+            "description": "The slack verification token, taken from the Slack page after create an app."
+         }
+      },
+      "slackBotToken": {
+         "type": "string",
+         "defaultValue": "",
+         "metadata": {
+            "description": "The slack bot token, taken from the Slack page after create an app."
+         }
+      },
+      "slackClientSigningSecret": {
+         "type": "string",
+         "defaultValue": "",
+         "metadata": {
+            "description": "The slack client signing secret, taken from the Slack page after create an app."
+         }
+      }
+   },
+   "variables": {
+      "defaultAppServicePlanName": "[if(empty(parameters('existingAppServicePlan')), 'createNewAppServicePlan', parameters('existingAppServicePlan'))]",
+      "useExistingAppServicePlan": "[not(equals(variables('defaultAppServicePlanName'), 'createNewAppServicePlan'))]",
+      "servicePlanName": "[if(variables('useExistingAppServicePlan'), parameters('existingAppServicePlan'), parameters('newAppServicePlanName'))]",
+      "publishingUsername": "[concat('$', parameters('newWebAppName'))]",
+      "resourcesLocation": "[parameters('appServicePlanLocation')]",
+      "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
+      "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
+      "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+   },
+   "resources": [
+      {
+         "comments": "Create a new Linux App Service Plan if no existing App Service Plan name was passed in.",
+         "type": "Microsoft.Web/serverfarms",
+         "apiVersion": "2016-09-01",
+         "name": "[variables('servicePlanName')]",
+         "location": "[variables('resourcesLocation')]",
+         "sku": "[parameters('newAppServicePlanSku')]",
+         "kind": "linux",
+         "properties": {
+            "name": "[variables('servicePlanName')]",
+            "perSiteScaling": false,
+            "reserved": true,
+            "targetWorkerCount": 0,
+            "targetWorkerSizeId": 0
+         }
+      },
+      {
+         "comments": "Create a Web App using a Linux App Service Plan",
+         "type": "Microsoft.Web/sites",
+         "apiVersion": "2016-08-01",
+         "name": "[variables('webAppName')]",
+         "location": "[variables('resourcesLocation')]",
+         "dependsOn": [
+            "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
+         ],
+         "kind": "app,linux",
+         "properties": {
+            "enabled": true,
+            "hostNameSslStates": [
+               {
+                  "name": "[concat(parameters('newWebAppName'), '.azurewebsites.net')]",
+                  "sslState": "Disabled",
+                  "hostType": "Standard"
+               },
+               {
+                  "name": "[concat(parameters('newWebAppName'), '.scm.azurewebsites.net')]",
+                  "sslState": "Disabled",
+                  "hostType": "Repository"
+               }
+            ],
+            "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
+            "reserved": true,
+            "scmSiteAlsoStopped": false,
+            "clientAffinityEnabled": false,
+            "clientCertEnabled": false,
+            "hostNamesDisabled": false,
+            "containerSize": 0,
+            "dailyMemoryTimeQuota": 0,
+            "httpsOnly": false,
+            "siteConfig": {
+               "appSettings": [
+                  {
+                     "name": "MicrosoftAppId",
+                     "value": "[parameters('appId')]"
+                  },
+                  {
+                     "name": "MicrosoftAppPassword",
+                     "value": "[parameters('appSecret')]"
+                  },
+                  {
+                     "name": "SlackVerificationToken",
+                     "value": "[parameters('slackVerificationToken')]"
+                  },
+                  {
+                     "name": "SlackBotToken",
+                     "value": "[parameters('slackBotToken')]"
+                  },
+                  {
+                     "name": "SlackClientSigningSecret",
+                     "value": "[parameters('slackClientSigningSecret')]"
+                  },
+                  {
+                     "name": "SCM_DO_BUILD_DURING_DEPLOYMENT",
+                     "value": "true"
+                  }
+               ],
+               "cors": {
+                  "allowedOrigins": [
+                     "https://botservice.hosting.portal.azure.net",
+                     "https://hosting.onecloud.azure-test.net/"
+                  ]
+               }
+            }
+         }
+      },
+      {
+         "type": "Microsoft.Web/sites/config",
+         "apiVersion": "2016-08-01",
+         "name": "[concat(variables('webAppName'), '/web')]",
+         "location": "[variables('resourcesLocation')]",
+         "dependsOn": [
+            "[resourceId('Microsoft.Web/sites', variables('webAppName'))]"
+         ],
+         "properties": {
+            "numberOfWorkers": 1,
+            "defaultDocuments": [
+               "Default.htm",
+               "Default.html",
+               "Default.asp",
+               "index.htm",
+               "index.html",
+               "iisstart.htm",
+               "default.aspx",
+               "index.php",
+               "hostingstart.html"
+            ],
+            "netFrameworkVersion": "v4.0",
+            "phpVersion": "",
+            "pythonVersion": "",
+            "nodeVersion": "",
+            "linuxFxVersion": "PYTHON|3.7",
+            "requestTracingEnabled": false,
+            "remoteDebuggingEnabled": false,
+            "remoteDebuggingVersion": "VS2017",
+            "httpLoggingEnabled": true,
+            "logsDirectorySizeLimit": 35,
+            "detailedErrorLoggingEnabled": false,
+            "publishingUsername": "[variables('publishingUsername')]",
+            "scmType": "None",
+            "use32BitWorkerProcess": true,
+            "webSocketsEnabled": false,
+            "alwaysOn": false,
+            "appCommandLine": "gunicorn --bind 0.0.0.0 --worker-class aiohttp.worker.GunicornWebWorker --timeout 600 app:APP",
+            "managedPipelineMode": "Integrated",
+            "virtualApplications": [
+               {
+                  "virtualPath": "/",
+                  "physicalPath": "site\\wwwroot",
+                  "preloadEnabled": false,
+                  "virtualDirectories": null
+               }
+            ],
+            "winAuthAdminState": 0,
+            "winAuthTenantState": 0,
+            "customAppPoolIdentityAdminState": false,
+            "customAppPoolIdentityTenantState": false,
+            "loadBalancing": "LeastRequests",
+            "routingRules": [],
+            "experiments": {
+               "rampUpRules": []
+            },
+            "autoHealEnabled": false,
+            "vnetName": "",
+            "minTlsVersion": "1.2",
+            "ftpsState": "AllAllowed",
+            "reservedInstanceCount": 0
+         }
+      },
+      {
+         "apiVersion": "2017-12-01",
+         "type": "Microsoft.BotService/botServices",
+         "name": "[parameters('botId')]",
+         "location": "global",
+         "kind": "bot",
+         "sku": {
+            "name": "[parameters('botSku')]"
+         },
+         "properties": {
+            "name": "[parameters('botId')]",
+            "displayName": "[parameters('botId')]",
+            "endpoint": "[variables('botEndpoint')]",
+            "msaAppId": "[parameters('appId')]",
+            "developerAppInsightsApplicationId": null,
+            "developerAppInsightKey": null,
+            "publishingCredentials": null,
+            "storageResourceId": null
+         },
+         "dependsOn": [
+            "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
+         ]
+      }
+   ]
+}

--- a/libraries/functional-tests/slacktestbot/requirements.txt
+++ b/libraries/functional-tests/slacktestbot/requirements.txt
@@ -1,0 +1,2 @@
+botbuilder-integration-aiohttp>=4.11.0
+botbuilder-adapters-slack>=4.11.0

--- a/libraries/functional-tests/slacktestbot/resources/InteractiveMessage.json
+++ b/libraries/functional-tests/slacktestbot/resources/InteractiveMessage.json
@@ -1,0 +1,62 @@
+[
+  {
+    "type": "section",
+    "text": {
+      "type": "mrkdwn",
+      "text": "Hello, Assistant to the Regional Manager Dwight! *Michael Scott* wants to know where you'd like to take the Paper Company investors to dinner tonight.\n\n *Please select a restaurant:*"
+    }
+  },
+  {
+    "type": "divider"
+  },
+  {
+    "type": "section",
+    "text": {
+      "type": "mrkdwn",
+      "text": "*Farmhouse Thai Cuisine*\n:star::star::star::star: 1528 reviews\n They do have some vegan options, like the roti and curry, plus they have a ton of salad stuff and noodles can be ordered without meat!! They have something for everyone here"
+    },
+    "accessory": {
+      "type": "image",
+      "image_url": "https://s3-media3.fl.yelpcdn.com/bphoto/c7ed05m9lC2EmA3Aruue7A/o.jpg",
+      "alt_text": "alt text for image"
+    }
+  },
+  {
+    "type": "section",
+    "text": {
+      "type": "mrkdwn",
+      "text": "*Ler Ros*\n:star::star::star::star: 2082 reviews\n I would really recommend the  Yum Koh Moo Yang - Spicy lime dressing and roasted quick marinated pork shoulder, basil leaves, chili & rice powder."
+    },
+    "accessory": {
+      "type": "image",
+      "image_url": "https://s3-media2.fl.yelpcdn.com/bphoto/DawwNigKJ2ckPeDeDM7jAg/o.jpg",
+      "alt_text": "alt text for image"
+    }
+  },
+  {
+    "type": "divider"
+  },
+  {
+    "type": "actions",
+    "elements": [
+      {
+        "type": "button",
+        "text": {
+          "type": "plain_text",
+          "text": "Farmhouse",
+          "emoji": true
+        },
+        "value": "Farmhouse"
+      },
+      {
+        "type": "button",
+        "text": {
+          "type": "plain_text",
+          "text": "Ler Ros",
+          "emoji": true
+        },
+        "value": "Ler Ros"
+      }
+    ]
+  }
+]

--- a/libraries/functional-tests/tests/test_slack_client.py
+++ b/libraries/functional-tests/tests/test_slack_client.py
@@ -25,7 +25,7 @@ class SlackClient(aiounittest.AsyncTestCase):
         # Assert
         self.assertEqual(f"Echo: {echo_guid}", response)
 
-    async def _receive_message_async(self):
+    async def _receive_message_async(self) -> str:
         last_message = ""
         i = 0
 
@@ -42,7 +42,7 @@ class SlackClient(aiounittest.AsyncTestCase):
 
         return last_message
 
-    async def _send_message_async(self, echo_guid: str):
+    async def _send_message_async(self, echo_guid: str) -> None:
         timestamp = str(int(datetime.datetime.utcnow().timestamp()))
         message = self._create_message(echo_guid)
         hub_signature = self._create_hub_signature(message, timestamp)
@@ -55,7 +55,7 @@ class SlackClient(aiounittest.AsyncTestCase):
 
         requests.post(url, headers=headers, data=message)
 
-    def _create_message(self, echo_guid: str):
+    def _create_message(self, echo_guid: str) -> str:
         slack_event = {
             "client_msg_id": "client_msg_id",
             "type": "message",
@@ -75,7 +75,7 @@ class SlackClient(aiounittest.AsyncTestCase):
 
         return json.dumps(message)
 
-    def _create_hub_signature(self, message: str, timestamp: str):
+    def _create_hub_signature(self, message: str, timestamp: str) -> str:
         signature = ["v0", timestamp, message]
         base_string = ":".join(signature)
 

--- a/libraries/functional-tests/tests/test_slack_client.py
+++ b/libraries/functional-tests/tests/test_slack_client.py
@@ -1,0 +1,114 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import hashlib
+import hmac
+import json
+import os
+import uuid
+import datetime
+import time
+import aiounittest
+import requests
+
+
+class SlackClient(aiounittest.AsyncTestCase):
+    async def test_send_and_receive_slack_message(self):
+        # Arrange
+        # self._get_environment_vars()
+        echo_guid = str(uuid.uuid4())
+
+        # Act
+        await self._send_message_async(echo_guid)
+        response = await self._receive_message_async()
+
+        # Assert
+        self.assertEqual(f"Echo: {echo_guid}", response)
+
+    async def _receive_message_async(self):
+        last_message = ""
+        i = 0
+
+        while "Echo" not in last_message and i < 60:
+            url = (
+                f"{self._slack_url_base}/conversations.history?token="
+                f"{self._slack_bot_token}&channel={self._slack_channel}"
+            )
+            response = requests.get(url,)
+            last_message = response.json()["messages"][0]["text"]
+
+            time.sleep(1)
+            i += 1
+
+        return last_message
+
+    async def _send_message_async(self, echo_guid: str):
+        timestamp = str(int(datetime.datetime.utcnow().timestamp()))
+        message = self._create_message(echo_guid)
+        hub_signature = self._create_hub_signature(message, timestamp)
+        headers = {
+            "X-Slack-Request-Timestamp": timestamp,
+            "X-Slack-Signature": hub_signature,
+            "Content-type": "application/json",
+        }
+        url = f"https://{self._bot_name}.azurewebsites.net/api/messages"
+
+        requests.post(url, headers=headers, data=message)
+
+    def _create_message(self, echo_guid: str):
+        slack_event = {
+            "client_msg_id": "client_msg_id",
+            "type": "message",
+            "text": echo_guid,
+            "user": "userId",
+            "channel": self._slack_channel,
+            "channel_type": "im",
+        }
+
+        message = {
+            "token": self._slack_verification_token,
+            "team_id": "team_id",
+            "api_app_id": "apiAppId",
+            "event": slack_event,
+            "type": "event_callback",
+        }
+
+        return json.dumps(message)
+
+    def _create_hub_signature(self, message: str, timestamp: str):
+        signature = ["v0", timestamp, message]
+        base_string = ":".join(signature)
+
+        computed_signature = "V0=" + hmac.new(
+            bytes(self._slack_client_signing_secret, encoding="utf8"),
+            msg=bytes(base_string, "utf-8"),
+            digestmod=hashlib.sha256,
+        ).hexdigest().upper().replace("-", "")
+
+        return computed_signature
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls._slack_url_base: str = "https://slack.com/api"
+
+        cls._slack_channel = os.getenv("SlackChannel")
+        if not cls._slack_channel:
+            raise Exception('Environment variable "SlackChannel" not found.')
+
+        cls._slack_bot_token = os.getenv("SlackBotToken")
+        if not cls._slack_bot_token:
+            raise Exception('Environment variable "SlackBotToken" not found.')
+
+        cls._slack_client_signing_secret = os.getenv("SlackClientSigningSecret")
+        if not cls._slack_client_signing_secret:
+            raise Exception(
+                'Environment variable "SlackClientSigningSecret" not found.'
+            )
+
+        cls._slack_verification_token = os.getenv("SlackVerificationToken")
+        if not cls._slack_verification_token:
+            raise Exception('Environment variable "SlackVerificationToken" not found.')
+
+        cls._bot_name = os.getenv("BotName")
+        if not cls._bot_name:
+            raise Exception('Environment variable "BotName" not found.')

--- a/libraries/functional-tests/tests/test_slack_client.py
+++ b/libraries/functional-tests/tests/test_slack_client.py
@@ -15,7 +15,6 @@ import requests
 class SlackClient(aiounittest.AsyncTestCase):
     async def test_send_and_receive_slack_message(self):
         # Arrange
-        # self._get_environment_vars()
         echo_guid = str(uuid.uuid4())
 
         # Act

--- a/pipelines/botbuilder-python-ci-slack-test.yml
+++ b/pipelines/botbuilder-python-ci-slack-test.yml
@@ -1,0 +1,104 @@
+#
+# Runs functional tests against the Slack channel.
+#
+
+# "name" here defines the build number format. Build number is accessed via $(Build.BuildNumber)
+name: $(Build.BuildId)
+
+pool:
+  vmImage: $[ coalesce( variables['VMImage'], 'windows-2019' ) ] # or 'windows-latest' or 'vs2017-win2016'
+
+trigger: # ci trigger
+  batch: true
+  branches:
+    include:
+    - main
+  paths:
+    include:
+    - '*'
+    exclude:
+    - doc/
+    - specs/
+    - LICENSE
+    - README.md
+    - UsingTestPyPI.md
+
+pr: # pr trigger
+  branches:
+    include:
+    - main
+  paths:
+    include:
+    - pipelines/botbuilder-python-ci-slack-test.yml
+
+variables:
+  AppId: $(SlackTestBotAppId)
+  AppSecret: $(SlackTestBotAppSecret)
+  BotGroup: $(SlackTestBotBotGroup)
+  BotName: $(SlackTestBotBotName)
+  SlackBotToken: $(SlackTestBotSlackBotToken)
+  SlackClientSigningSecret: $(SlackTestBotSlackClientSigningSecret)
+  SlackVerificationToken: $(SlackTestBotSlackVerificationToken)
+#  AzureSubscription: define this in Azure
+#  SlackTestBotAppId: define this in Azure
+#  SlackTestBotAppSecret: define this in Azure
+#  SlackTestBotBotGroup: define this in Azure
+#  SlackTestBotBotName: define this in Azure
+#  SlackTestBotSlackBotToken: define this in Azure
+#  SlackTestBotSlackChannel: define this in Azure
+#  SlackTestBotSlackClientSigningSecret: define this in Azure
+#  SlackTestBotSlackVerificationToken: define this in Azure
+
+steps:
+- powershell: 'gci env:* | sort-object name | Format-Table -AutoSize -Wrap'
+  displayName: 'Display env vars'
+
+- task: AzureCLI@2
+  displayName: 'Create Azure resources'
+  inputs:
+    azureSubscription: $(AzureSubscription)
+    scriptType: pscore
+    scriptLocation: inlineScript
+    inlineScript: |
+      Set-PSDebug -Trace 1;
+      # set up resource group, bot channels registration, app service, app service plan
+      az deployment sub create --name "$(BotName)" --template-file "$(System.DefaultWorkingDirectory)/libraries/functional-tests/slacktestbot/deploymentTemplates/template-with-new-rg.json" --location "westus" --parameters groupName="$(BotGroup)" appId="$(AppId)" appSecret="$(AppSecret)" botId="$(BotName)" botSku="F0" newAppServicePlanName="$(BotName)" newWebAppName="$(BotName)" slackVerificationToken="$(SlackVerificationToken)" slackBotToken="$(SlackBotToken)" slackClientSigningSecret="$(SlackClientSigningSecret)" groupLocation="westus" newAppServicePlanLocation="westus";
+      Set-PSDebug -Trace 0;
+
+- powershell: |
+    7z a -tzip "$(System.DefaultWorkingDirectory)/libraries/functional-tests/slacktestbot/bot.zip"  "$(System.DefaultWorkingDirectory)/libraries/functional-tests/slacktestbot/*" -aoa
+  displayName: 'Zip Bot'
+
+- task: AzureCLI@1
+  displayName: 'Deploy bot'
+  inputs:
+    azureSubscription: $(AzureSubscription)
+    scriptType: ps
+    scriptLocation: inlineScript
+    inlineScript: |
+      az webapp deployment source config-zip --resource-group "$(BotGroup)" --name "$(BotName)" --src "$(System.DefaultWorkingDirectory)/libraries/functional-tests/slacktestbot/bot.zip" --timeout 600000
+
+- script: |
+    python -m pip install --upgrade pip
+    pip install -r ./libraries/functional-tests/requirements.txt
+    pip install pytest
+  displayName: 'Install test dependencies'
+
+- script: |
+    pytest test_slack_client.py
+  workingDirectory: '$(System.DefaultWorkingDirectory)/libraries/functional-tests/tests/'
+  displayName: Run test
+  env:
+    BotName: $(SlackTestBotBotName)
+    SlackBotToken: $(SlackTestBotSlackBotToken)
+    SlackChannel: $(SlackTestBotSlackChannel)
+    SlackClientSigningSecret: $(SlackTestBotSlackClientSigningSecret)
+    SlackVerificationToken: $(SlackTestBotSlackVerificationToken)
+
+- task: AzureCLI@1
+  displayName: 'Delete resources'
+  inputs:
+    azureSubscription: $(AzureSubscription)
+    scriptLocation: inlineScript
+    inlineScript: 'call az group delete -n "$(BotGroup)" --yes'
+  condition: and(always(), ne(variables['DeleteResourceGroup'], 'false'))

--- a/pipelines/botbuilder-python-ci-slack-test.yml
+++ b/pipelines/botbuilder-python-ci-slack-test.yml
@@ -76,7 +76,7 @@ steps:
     scriptType: ps
     scriptLocation: inlineScript
     inlineScript: |
-      az webapp deployment source config-zip --resource-group "$(BotGroup)" --name "$(BotName)" --src "$(System.DefaultWorkingDirectory)/libraries/functional-tests/slacktestbot/bot.zip" --timeout 600000
+      az webapp deployment source config-zip --resource-group "$(BotGroup)" --name "$(BotName)" --src "$(System.DefaultWorkingDirectory)/libraries/functional-tests/slacktestbot/bot.zip" --timeout 300
 
 - script: |
     python -m pip install --upgrade pip

--- a/pipelines/botbuilder-python-ci-slack-test.yml
+++ b/pipelines/botbuilder-python-ci-slack-test.yml
@@ -48,6 +48,7 @@ variables:
 #  SlackTestBotSlackChannel: define this in Azure
 #  SlackTestBotSlackClientSigningSecret: define this in Azure
 #  SlackTestBotSlackVerificationToken: define this in Azure
+#  DeleteResourceGroup: (optional) define in Azure
 
 steps:
 - powershell: 'gci env:* | sort-object name | Format-Table -AutoSize -Wrap'


### PR DESCRIPTION
Fixes # 631

## Description
This PR ports the Slack adapter functional test from PR# 3108 from botbuilder-dotnet.

## Specific Changes

  - Adds slacktestbot (migrated from [BotBuilder-Samples/samples/python/60.slack-adapter](https://github.com/microsoft/BotBuilder-Samples/tree/main/samples/python/60.slack-adapter))
  - Adds `test_slack_client.py` 
  - Adds `requirements.txt` in the _functional-tests_ library
  - Adds pipeline definition YAML to deploy the bot and run the test.

Note: SlackHistoryRetrieve port was not required, in DotNet it is used by JsonDeserealize to get the response message, but in Python, the implementation differs.

## Testing
The following images showcase the pipeline running the test successfully and how it looks on the bot through Slack:
![image](https://user-images.githubusercontent.com/64803884/99302476-2e942700-282e-11eb-8301-a90d0e93e1e6.png)
![image](https://user-images.githubusercontent.com/64803884/99302664-71ee9580-282e-11eb-9fc3-502335b632b3.png)
