### PR TITLE
[#XXX][BotFrameworkAdapter] process_activity returns HTTP 412 error when exchanging a token

### DIFF
--- a/libraries/botbuilder-core/botbuilder/core/bot_framework_adapter.py
+++ b/libraries/botbuilder-core/botbuilder/core/bot_framework_adapter.py
@@ -36,6 +36,7 @@ from botframework.connector.token_api.models import (
     TokenStatus,
     TokenExchangeRequest,
     SignInUrlResponse,
+    TokenResponse as ConnectorTokenResponse,
 )
 from botbuilder.schema import (
     Activity,
@@ -509,7 +510,10 @@ class BotFrameworkAdapter(
             )
             if invoke_response is None:
                 return InvokeResponse(status=int(HTTPStatus.NOT_IMPLEMENTED))
-            return invoke_response.value
+            return InvokeResponse(
+                status=invoke_response.value.status,
+                body=invoke_response.value.body.serialize(),
+            )
 
         return None
 
@@ -1267,8 +1271,13 @@ class BotFrameworkAdapter(
             exchange_request.token,
         )
 
-        if isinstance(result, TokenResponse):
-            return result
+        if isinstance(result, ConnectorTokenResponse):
+            return TokenResponse(
+                channel_id=result.channel_id,
+                connection_name=result.connection_name,
+                token=result.token,
+                expiration=result.expiration,
+            )
         raise TypeError(f"exchange_async returned improper result: {type(result)}")
 
     @staticmethod


### PR DESCRIPTION
Fixes # XXX

## Description
This PR fixes an issue when exchanging a token from the Host to the Skill the response comes with **412** status and a body description of `The bot is unable to exchange token. Proceed with regular login.` by evaluating the correct `exchange_async` method response and returning the actual `TokenResponse` instance.
There is also a fix for the InvokeResponse result in the `process_activity` method, that now will be returning the body serialized.
Also, two new unit tests were included to address these fixes.

## Specific Changes
- **bot_framework_adapter.py**
  - Imported `TokenResponse` from `botframework.connector.token_api.models` as `ConnectorTokenResponse` named class due to existing `TokenResponse` from `bot.builder.schema`.
  - Replaced `invoke_response.value` in `process_activity_with_identity` with a new instance with the body serialized.
  - Replaced the condition after the exchange_async token is executed in the `exchange_token_from_credentials` method for evaluating with the `ConnectorTokenResponse` and returning the `TokenResponse` instance.
- **test_bot_framework_adapter.py** 
  - Added the mock `_create_token_api_client` method in the `AdapterUnderTest` class to mock the `exchange_async` method.
  - Added the test `test_process_activity_with_identity_token_exchange_invoke_response` that will evaluate that the InvokeResponse comes serialized.
  - Added the test `test_exchange_token_from_credentials` that will evaluate that returns the `TokenResponse` correctly. 

## Testing
![image](https://user-images.githubusercontent.com/62260472/113917905-32621f00-97b8-11eb-9ac1-ce08d4efe03a.png)
![image](https://user-images.githubusercontent.com/62260472/113918003-4e65c080-97b8-11eb-93fd-76c5e7165741.png)
