### PR TITLE
[#xxx][Dialogs] Remove hardcoded InputHint for AttachmentPrompt

### DIFF
--- a/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/attachment_prompt.py
+++ b/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/attachment_prompt.py
@@ -39,10 +39,8 @@ class AttachmentPrompt(Prompt):
             )
 
         if is_retry and options.retry_prompt:
-            options.retry_prompt.input_hint = InputHints.expecting_input
             await turn_context.send_activity(options.retry_prompt)
         elif options.prompt:
-            options.prompt.input_hint = InputHints.expecting_input
             await turn_context.send_activity(options.prompt)
 
     async def on_recognize(

--- a/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/attachment_prompt.py
+++ b/libraries/botbuilder-dialogs/botbuilder/dialogs/prompts/attachment_prompt.py
@@ -3,7 +3,7 @@
 
 from typing import Callable, Dict
 
-from botbuilder.schema import ActivityTypes, InputHints
+from botbuilder.schema import ActivityTypes
 from botbuilder.core import TurnContext
 
 from .prompt import Prompt, PromptValidatorContext

--- a/libraries/botbuilder-dialogs/tests/test_attachment_prompt.py
+++ b/libraries/botbuilder-dialogs/tests/test_attachment_prompt.py
@@ -77,7 +77,7 @@ class AttachmentPromptTests(aiounittest.AsyncTestCase):
         prompt_activity = Activity(
             type=ActivityTypes.message,
             text="please add an attachment.",
-            input_hint=InputHints.accepting_input
+            input_hint=InputHints.accepting_input,
         )
 
         async def exec_test(turn_context: TurnContext):
@@ -86,9 +86,7 @@ class AttachmentPromptTests(aiounittest.AsyncTestCase):
             results = await dialog_context.continue_dialog()
 
             if results.status == DialogTurnStatus.Empty:
-                options = PromptOptions(
-                    prompt=copy.copy(prompt_activity)
-                )
+                options = PromptOptions(prompt=copy.copy(prompt_activity))
                 await dialog_context.prompt("AttachmentPrompt", options)
             elif results.status == DialogTurnStatus.Complete:
                 attachment = results.result[0]

--- a/libraries/botbuilder-dialogs/tests/test_attachment_prompt.py
+++ b/libraries/botbuilder-dialogs/tests/test_attachment_prompt.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+import copy
 import aiounittest
 from botbuilder.dialogs.prompts import (
     AttachmentPrompt,
@@ -17,8 +18,6 @@ from botbuilder.core import (
 )
 from botbuilder.core.adapters import TestAdapter
 from botbuilder.dialogs import DialogSet, DialogTurnStatus
-
-import copy
 
 
 class AttachmentPromptTests(aiounittest.AsyncTestCase):

--- a/libraries/botbuilder-dialogs/tests/test_attachment_prompt.py
+++ b/libraries/botbuilder-dialogs/tests/test_attachment_prompt.py
@@ -7,7 +7,7 @@ from botbuilder.dialogs.prompts import (
     PromptOptions,
     PromptValidatorContext,
 )
-from botbuilder.schema import Activity, ActivityTypes, Attachment
+from botbuilder.schema import Activity, ActivityTypes, Attachment, InputHints
 
 from botbuilder.core import (
     TurnContext,
@@ -17,6 +17,8 @@ from botbuilder.core import (
 )
 from botbuilder.core.adapters import TestAdapter
 from botbuilder.dialogs import DialogSet, DialogTurnStatus
+
+import copy
 
 
 class AttachmentPromptTests(aiounittest.AsyncTestCase):
@@ -70,6 +72,44 @@ class AttachmentPromptTests(aiounittest.AsyncTestCase):
         step2 = await step1.assert_reply("please add an attachment.")
         step3 = await step2.send(attachment_activity)
         await step3.assert_reply("some content")
+
+    async def test_attachment_prompt_with_input_hint(self):
+        prompt_activity = Activity(
+            type=ActivityTypes.message,
+            text="please add an attachment.",
+            input_hint=InputHints.accepting_input
+        )
+
+        async def exec_test(turn_context: TurnContext):
+            dialog_context = await dialogs.create_context(turn_context)
+
+            results = await dialog_context.continue_dialog()
+
+            if results.status == DialogTurnStatus.Empty:
+                options = PromptOptions(
+                    prompt=copy.copy(prompt_activity)
+                )
+                await dialog_context.prompt("AttachmentPrompt", options)
+            elif results.status == DialogTurnStatus.Complete:
+                attachment = results.result[0]
+                content = MessageFactory.text(attachment.content)
+                await turn_context.send_activity(content)
+
+            await convo_state.save_changes(turn_context)
+
+        # Initialize TestAdapter.
+        adapter = TestAdapter(exec_test)
+
+        # Create ConversationState with MemoryStorage and register the state as middleware.
+        convo_state = ConversationState(MemoryStorage())
+
+        # Create a DialogState property, DialogSet and AttachmentPrompt.
+        dialog_state = convo_state.create_property("dialog_state")
+        dialogs = DialogSet(dialog_state)
+        dialogs.add(AttachmentPrompt("AttachmentPrompt"))
+
+        step1 = await adapter.send("hello")
+        await step1.assert_reply(prompt_activity)
 
     async def test_attachment_prompt_with_validator(self):
         async def exec_test(turn_context: TurnContext):


### PR DESCRIPTION
#minor -> replace for fixes x when promoted
Fixes # 12 in sw

## Description
This PR fixes the issue with the attachment prompt forcing the Input Hint on prompt and adds a new unit test to validate the change.

## Specific Changes
<!-- Please list the changes in a concise manner. -->

  - Remove lines in `attachment_prompt.py` that force the input_hint.
  - Add unit test `test_attachment_prompt_with_input_hint` that uses an activity with the input hint set, and validates that when used the properties are not changed.

## Testing

Below is the added unit test working before and after the change is applied.
![image](https://user-images.githubusercontent.com/38112957/117015903-8d5c3880-acc8-11eb-8c28-e16246c56954.png)

And below is the 05.multi-turn botbuilder sample using the library with the changes applied.
![image](https://user-images.githubusercontent.com/38112957/117015352-03ac6b00-acc8-11eb-9e6f-d1c8fc961571.png)

