### PR TITLE
[#1687][PORT] [SkillConversationIdFactory] Add SkillConversationIdFactory to Python

### DIFF
--- a/libraries/botbuilder-core/botbuilder/core/skills/__init__.py
+++ b/libraries/botbuilder-core/botbuilder/core/skills/__init__.py
@@ -8,6 +8,7 @@
 from .bot_framework_skill import BotFrameworkSkill
 from .bot_framework_client import BotFrameworkClient
 from .conversation_id_factory import ConversationIdFactoryBase
+from .skill_conversation_id_factory import SkillConversationIdFactory
 from .skill_handler import SkillHandler
 from .skill_conversation_id_factory_options import SkillConversationIdFactoryOptions
 from .skill_conversation_reference import SkillConversationReference
@@ -16,6 +17,7 @@ __all__ = [
     "BotFrameworkSkill",
     "BotFrameworkClient",
     "ConversationIdFactoryBase",
+    "SkillConversationIdFactory",
     "SkillConversationIdFactoryOptions",
     "SkillConversationReference",
     "SkillHandler",

--- a/libraries/botbuilder-core/botbuilder/core/skills/conversation_id_factory.py
+++ b/libraries/botbuilder-core/botbuilder/core/skills/conversation_id_factory.py
@@ -56,7 +56,7 @@ class ConversationIdFactoryBase(ABC):
         """
         raise NotImplementedError()
 
-    @abstractmethod
+    # @abstractmethod
     async def get_skill_conversation_reference(
         self, skill_conversation_id: str
     ) -> SkillConversationReference:

--- a/libraries/botbuilder-core/botbuilder/core/skills/conversation_id_factory.py
+++ b/libraries/botbuilder-core/botbuilder/core/skills/conversation_id_factory.py
@@ -41,7 +41,7 @@ class ConversationIdFactoryBase(ABC):
         """
         raise NotImplementedError()
 
-    @abstractmethod
+    # @abstractmethod
     async def get_conversation_reference(
         self, skill_conversation_id: str
     ) -> ConversationReference:

--- a/libraries/botbuilder-core/botbuilder/core/skills/conversation_id_factory.py
+++ b/libraries/botbuilder-core/botbuilder/core/skills/conversation_id_factory.py
@@ -44,16 +44,28 @@ class ConversationIdFactoryBase(ABC):
     @abstractmethod
     async def get_conversation_reference(
         self, skill_conversation_id: str
-    ) -> Union[SkillConversationReference, ConversationReference]:
+    ) -> ConversationReference:
+        """
+        [DEPRECATED] Method is deprecated, please use get_skill_conversation_reference() instead.
+
+        Retrieves a :class:`ConversationReference` using a conversation id passed in.
+
+        :param skill_conversation_id: The conversation id for which to retrieve the :class:`ConversationReference`.
+        :type skill_conversation_id: str
+        :returns: `ConversationReference` for the specified ID.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def get_skill_conversation_reference(
+        self, skill_conversation_id: str
+    ) -> SkillConversationReference:
         """
         Retrieves a :class:`SkillConversationReference` using a conversation id passed in.
 
         :param skill_conversation_id: The conversation id for which to retrieve the :class:`SkillConversationReference`.
         :type skill_conversation_id: str
-
-        .. note::
-            SkillConversationReference is the preferred return type, while the :class:`SkillConversationReference`
-            type is provided for backwards compatability.
+        :returns: `SkillConversationReference` for the specified ID.
         """
         raise NotImplementedError()
 

--- a/libraries/botbuilder-core/botbuilder/core/skills/conversation_id_factory.py
+++ b/libraries/botbuilder-core/botbuilder/core/skills/conversation_id_factory.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-from abc import ABC, abstractmethod
+from abc import ABC
 from typing import Union
 from botbuilder.schema import ConversationReference
 from .skill_conversation_id_factory_options import SkillConversationIdFactoryOptions
@@ -17,7 +17,6 @@ class ConversationIdFactoryBase(ABC):
         SkillConversationReferences and deletion.
     """
 
-    @abstractmethod
     async def create_skill_conversation_id(
         self,
         options_or_conversation_reference: Union[
@@ -41,7 +40,6 @@ class ConversationIdFactoryBase(ABC):
         """
         raise NotImplementedError()
 
-    # @abstractmethod
     async def get_conversation_reference(
         self, skill_conversation_id: str
     ) -> ConversationReference:
@@ -56,7 +54,6 @@ class ConversationIdFactoryBase(ABC):
         """
         raise NotImplementedError()
 
-    # @abstractmethod
     async def get_skill_conversation_reference(
         self, skill_conversation_id: str
     ) -> SkillConversationReference:
@@ -69,7 +66,6 @@ class ConversationIdFactoryBase(ABC):
         """
         raise NotImplementedError()
 
-    @abstractmethod
     async def delete_conversation_reference(self, skill_conversation_id: str):
         """
         Removes any reference to objects keyed on the conversation id passed in.

--- a/libraries/botbuilder-core/botbuilder/core/skills/skill_conversation_id_factory.py
+++ b/libraries/botbuilder-core/botbuilder/core/skills/skill_conversation_id_factory.py
@@ -1,0 +1,59 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from botbuilder.core import TurnContext, Storage
+from botbuilder.core.skills import (
+    ConversationIdFactoryBase,
+    SkillConversationIdFactoryOptions,
+    SkillConversationReference,
+)
+from botbuilder.schema import ConversationReference
+from uuid import uuid4 as uuid
+
+class SkillConversationIdFactory(ConversationIdFactoryBase):
+    def __init__(self, storage: Storage):
+        if not storage:
+            raise TypeError("storage can't be None")
+
+        self._storage = storage
+
+    async def create_skill_conversation_id(
+        self,
+        options: SkillConversationIdFactoryOptions
+    ) -> str:
+        if not options:
+            raise TypeError("SkillConversationIdFactory() options can't be None")
+
+        conversation_reference = TurnContext.get_conversation_reference(options.activity)
+
+        skill_conversation_id = str(uuid())
+
+        skill_conversation_reference = SkillConversationReference(
+            conversation_reference=ConversationReference(conversation_reference),
+            oauth_scope=options.from_bot_oauth_scope
+        )
+
+        skill_conversation_info = { [skill_conversation_id]: skill_conversation_reference }
+
+        await self._storage.write(skill_conversation_info)
+
+        return skill_conversation_id
+
+    async def get_conversation_reference(
+        self, 
+        skill_conversation_id: str
+    ) -> SkillConversationReference:
+        if not skill_conversation_id:
+            raise TypeError("skill_conversation_id can't be None")
+
+        skill_conversation_reference = await self._storage.read([skill_conversation_id])
+        if not skill_conversation_reference:
+            raise TypeError("skill_conversation_reference")
+
+        return SkillConversationReference(skill_conversation_reference)
+
+    async def delete_conversation_reference(
+        self,
+        skill_conversation_id: str
+    ):
+        await self._storage.delete([skill_conversation_id])

--- a/libraries/botbuilder-core/botbuilder/core/skills/skill_conversation_id_factory.py
+++ b/libraries/botbuilder-core/botbuilder/core/skills/skill_conversation_id_factory.py
@@ -1,10 +1,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-import json
 from uuid import uuid4 as uuid
 from botbuilder.core import TurnContext, Storage
-from botbuilder.schema import ConversationReference
 from .conversation_id_factory import ConversationIdFactoryBase
 from .skill_conversation_id_factory_options import SkillConversationIdFactoryOptions
 from .skill_conversation_reference import SkillConversationReference

--- a/libraries/botbuilder-core/botbuilder/core/skills/skill_conversation_id_factory.py
+++ b/libraries/botbuilder-core/botbuilder/core/skills/skill_conversation_id_factory.py
@@ -21,39 +21,68 @@ class SkillConversationIdFactory(ConversationIdFactoryBase):
         self,
         options: SkillConversationIdFactoryOptions
     ) -> str:
+        """
+        Creates a new `SkillConversationReference`.
+
+        :param options: Creation options to use when creating the `SkillConversationReference`.
+        :type options: :class:`botbuilder.core.skills.SkillConversationIdFactoryOptions`
+        :return: ID of the created `SkillConversationReference`.
+        """
+
         if not options:
-            raise TypeError("SkillConversationIdFactory() options can't be None")
+            raise TypeError("options can't be None")
 
         conversation_reference = TurnContext.get_conversation_reference(options.activity)
 
         skill_conversation_id = str(uuid())
 
+        # Create the SkillConversationReference instance.
         skill_conversation_reference = SkillConversationReference(
             conversation_reference=ConversationReference(conversation_reference),
             oauth_scope=options.from_bot_oauth_scope
         )
 
+        # Store the SkillConversationReference using the skill_conversation_id as a key.
         skill_conversation_info = { [skill_conversation_id]: skill_conversation_reference }
 
         await self._storage.write(skill_conversation_info)
 
+        # Return the generated skill_conversation_id (that will be also used as the conversation ID to call the skill).
         return skill_conversation_id
 
-    async def get_conversation_reference(
+    async def get_skill_conversation_reference(
         self, 
         skill_conversation_id: str
     ) -> SkillConversationReference:
+        """
+        Retrieve a `SkillConversationReference` with the specified ID.
+
+        :param skill_conversation_id: The ID of the `SkillConversationReference` to retrieve.
+        :type skill_conversation_id: str
+        :return: `SkillConversationReference` for the specified ID; None if not found.
+        """
+
         if not skill_conversation_id:
             raise TypeError("skill_conversation_id can't be None")
 
+        # Get the SkillConversationReference from storage for the given skill_conversation_id.
         skill_conversation_reference = await self._storage.read([skill_conversation_id])
-        if not skill_conversation_reference:
-            raise TypeError("skill_conversation_reference")
 
-        return SkillConversationReference(skill_conversation_reference)
+        if skill_conversation_reference:
+            return SkillConversationReference(skill_conversation_reference)
+
+        return None
 
     async def delete_conversation_reference(
         self,
         skill_conversation_id: str
     ):
+        """
+        Deletes the `SkillConversationReference` with the specified ID.
+
+        :param skill_conversation_id: The ID of the `SkillConversationReference` to be deleted.
+        :type skill_conversation_id: str
+        """
+
+        # Delete the SkillConversationReference from storage.
         await self._storage.delete([skill_conversation_id])

--- a/libraries/botbuilder-core/botbuilder/core/skills/skill_conversation_id_factory.py
+++ b/libraries/botbuilder-core/botbuilder/core/skills/skill_conversation_id_factory.py
@@ -1,14 +1,13 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-from botbuilder.core import TurnContext, Storage
-from botbuilder.core.skills import (
-    ConversationIdFactoryBase,
-    SkillConversationIdFactoryOptions,
-    SkillConversationReference,
-)
-from botbuilder.schema import ConversationReference
+import json
 from uuid import uuid4 as uuid
+from botbuilder.core import TurnContext, Storage
+from botbuilder.schema import ConversationReference
+from .conversation_id_factory import ConversationIdFactoryBase
+from .skill_conversation_id_factory_options import SkillConversationIdFactoryOptions
+from .skill_conversation_reference import SkillConversationReference
 
 class SkillConversationIdFactory(ConversationIdFactoryBase):
     def __init__(self, storage: Storage):
@@ -38,12 +37,12 @@ class SkillConversationIdFactory(ConversationIdFactoryBase):
 
         # Create the SkillConversationReference instance.
         skill_conversation_reference = SkillConversationReference(
-            conversation_reference=ConversationReference(conversation_reference),
+            conversation_reference=conversation_reference,
             oauth_scope=options.from_bot_oauth_scope
         )
 
         # Store the SkillConversationReference using the skill_conversation_id as a key.
-        skill_conversation_info = { [skill_conversation_id]: skill_conversation_reference }
+        skill_conversation_info = { skill_conversation_id: skill_conversation_reference }
 
         await self._storage.write(skill_conversation_info)
 
@@ -68,10 +67,7 @@ class SkillConversationIdFactory(ConversationIdFactoryBase):
         # Get the SkillConversationReference from storage for the given skill_conversation_id.
         skill_conversation_reference = await self._storage.read([skill_conversation_id])
 
-        if skill_conversation_reference:
-            return SkillConversationReference(skill_conversation_reference)
-
-        return None
+        return skill_conversation_reference.get(skill_conversation_id)
 
     async def delete_conversation_reference(
         self,

--- a/libraries/botbuilder-core/botbuilder/core/skills/skill_handler.py
+++ b/libraries/botbuilder-core/botbuilder/core/skills/skill_handler.py
@@ -20,8 +20,7 @@ from botframework.connector.auth import (
     JwtTokenValidation,
 )
 from .skill_conversation_reference import SkillConversationReference
-from .conversation_id_factory import ConversationIdFactoryBase
-
+from .skill_conversation_id_factory import SkillConversationIdFactory
 
 class SkillHandler(ChannelServiceHandler):
 
@@ -33,7 +32,7 @@ class SkillHandler(ChannelServiceHandler):
         self,
         adapter: BotAdapter,
         bot: Bot,
-        conversation_id_factory: ConversationIdFactoryBase,
+        conversation_id_factory: SkillConversationIdFactory,
         credential_provider: CredentialProvider,
         auth_configuration: AuthenticationConfiguration,
         channel_provider: ChannelProvider = None,

--- a/libraries/botbuilder-core/botbuilder/core/skills/skill_handler.py
+++ b/libraries/botbuilder-core/botbuilder/core/skills/skill_handler.py
@@ -185,9 +185,9 @@ class SkillHandler(ChannelServiceHandler):
                 conversation_id
             )
         except NotImplementedError:
-            self._logger.warning(
-                "Got NotImplementedError when trying to call get_skill_conversation_reference() on the SkillConversationIdFactory, attempting to use deprecated get_conversation_reference() method instead."
-            )
+            # self._logger.warning(
+            #     "Got NotImplementedError when trying to call get_skill_conversation_reference() on the SkillConversationIdFactory, attempting to use deprecated get_conversation_reference() method instead."
+            # )
 
             # Attempt to get SkillConversationReference using deprecated method.
             # this catch should be removed once we remove the deprecated method. 

--- a/libraries/botbuilder-core/botbuilder/core/skills/skill_handler.py
+++ b/libraries/botbuilder-core/botbuilder/core/skills/skill_handler.py
@@ -23,6 +23,7 @@ from botframework.connector.auth import (
 from .skill_conversation_reference import SkillConversationReference
 from .conversation_id_factory import ConversationIdFactoryBase
 
+
 class SkillHandler(ChannelServiceHandler):
 
     SKILL_CONVERSATION_REFERENCE_KEY = (
@@ -187,11 +188,13 @@ class SkillHandler(ChannelServiceHandler):
             )
         except NotImplementedError:
             self._logger.warning(
-                "Got NotImplementedError when trying to call get_skill_conversation_reference() on the SkillConversationIdFactory, attempting to use deprecated get_conversation_reference() method instead."
+                "Got NotImplementedError when trying to call get_skill_conversation_reference() "
+                "on the SkillConversationIdFactory, attempting to use deprecated "
+                "get_conversation_reference() method instead."
             )
 
             # Attempt to get SkillConversationReference using deprecated method.
-            # this catch should be removed once we remove the deprecated method. 
+            # this catch should be removed once we remove the deprecated method.
             # We need to use the deprecated method for backward compatibility.
             conversation_reference = await self._conversation_id_factory.get_conversation_reference(
                 conversation_id

--- a/libraries/botbuilder-core/botbuilder/core/skills/skill_handler.py
+++ b/libraries/botbuilder-core/botbuilder/core/skills/skill_handler.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 from uuid import uuid4
+from logging import Logger, getLogger
 
 from botbuilder.core import Bot, BotAdapter, ChannelServiceHandler, TurnContext
 from botbuilder.schema import (
@@ -36,7 +37,7 @@ class SkillHandler(ChannelServiceHandler):
         credential_provider: CredentialProvider,
         auth_configuration: AuthenticationConfiguration,
         channel_provider: ChannelProvider = None,
-        logger: object = None,
+        logger: Logger = None,
     ):
         super().__init__(credential_provider, auth_configuration, channel_provider)
 
@@ -50,7 +51,7 @@ class SkillHandler(ChannelServiceHandler):
         self._adapter = adapter
         self._bot = bot
         self._conversation_id_factory = conversation_id_factory
-        self._logger = logger
+        self._logger = logger or getLogger()
 
     async def on_send_to_conversation(
         self, claims_identity: ClaimsIdentity, conversation_id: str, activity: Activity,
@@ -185,9 +186,9 @@ class SkillHandler(ChannelServiceHandler):
                 conversation_id
             )
         except NotImplementedError:
-            # self._logger.warning(
-            #     "Got NotImplementedError when trying to call get_skill_conversation_reference() on the SkillConversationIdFactory, attempting to use deprecated get_conversation_reference() method instead."
-            # )
+            self._logger.warning(
+                "Got NotImplementedError when trying to call get_skill_conversation_reference() on the SkillConversationIdFactory, attempting to use deprecated get_conversation_reference() method instead."
+            )
 
             # Attempt to get SkillConversationReference using deprecated method.
             # this catch should be removed once we remove the deprecated method. 

--- a/libraries/botbuilder-core/tests/skills/test_skill_conversation_id_factory.py
+++ b/libraries/botbuilder-core/tests/skills/test_skill_conversation_id_factory.py
@@ -33,13 +33,13 @@ class SkillConversationIdFactoryForTest(AsyncTestCase):
         skill_conversation_id = await self._skill_conversation_id_factory.create_skill_conversation_id(
             options= SkillConversationIdFactoryOptions(
                 activity=self._build_message_activity(conversation_reference),
-                bot_framework_skill=self._build_bot_framework_skill,
+                bot_framework_skill=self._build_bot_framework_skill(),
                 from_bot_id=self._bot_id,
                 from_bot_oauth_scope=self._bot_id
             )
         )
 
-        self.assertFalse(skill_conversation_id == None, "Expected a valid skill conversation ID to be created")
+        assert skill_conversation_id and skill_conversation_id.strip(), "Expected a valid skill conversation ID to be created"
 
         # Retrieve skill conversation
         retrieved_conversation_reference = await self._skill_conversation_id_factory.get_skill_conversation_reference(skill_conversation_id)
@@ -108,5 +108,5 @@ class SkillConversationIdFactoryForTest(AsyncTestCase):
         return BotFrameworkSkill(
             app_id=self._application_id,
             id=self.SKILL_ID,
-            skill_endpoint=""
+            skill_endpoint=self.SERVICE_URL
         )

--- a/libraries/botbuilder-core/tests/skills/test_skill_conversation_id_factory.py
+++ b/libraries/botbuilder-core/tests/skills/test_skill_conversation_id_factory.py
@@ -1,8 +1,6 @@
 from uuid import uuid4 as uuid
 from aiounittest import AsyncTestCase
-from botbuilder.core import (
-    MemoryStorage,
-)
+from botbuilder.core import MemoryStorage
 from botbuilder.schema import (
     Activity,
     ConversationAccount,
@@ -14,6 +12,7 @@ from botbuilder.core.skills import (
     SkillConversationIdFactoryOptions,
 )
 
+
 class SkillConversationIdFactoryForTest(AsyncTestCase):
     SERVICE_URL = "http://testbot.com/api/messages"
     SKILL_ID = "skill"
@@ -24,75 +23,79 @@ class SkillConversationIdFactoryForTest(AsyncTestCase):
         cls._application_id = str(uuid())
         cls._bot_id = str(uuid())
 
-    async def test_skill_conversation_id_factory_happy_path(
-        self
-    ):
+    async def test_skill_conversation_id_factory_happy_path(self):
         conversation_reference = self._build_conversation_reference()
 
         # Create skill conversation
         skill_conversation_id = await self._skill_conversation_id_factory.create_skill_conversation_id(
-            options= SkillConversationIdFactoryOptions(
+            options=SkillConversationIdFactoryOptions(
                 activity=self._build_message_activity(conversation_reference),
                 bot_framework_skill=self._build_bot_framework_skill(),
                 from_bot_id=self._bot_id,
-                from_bot_oauth_scope=self._bot_id
+                from_bot_oauth_scope=self._bot_id,
             )
         )
 
-        assert skill_conversation_id and skill_conversation_id.strip(), "Expected a valid skill conversation ID to be created"
+        assert (
+            skill_conversation_id and skill_conversation_id.strip()
+        ), "Expected a valid skill conversation ID to be created"
 
         # Retrieve skill conversation
-        retrieved_conversation_reference = await self._skill_conversation_id_factory.get_skill_conversation_reference(skill_conversation_id)
+        retrieved_conversation_reference = await self._skill_conversation_id_factory.get_skill_conversation_reference(
+            skill_conversation_id
+        )
 
         # Delete
-        await self._skill_conversation_id_factory.delete_conversation_reference(skill_conversation_id)
+        await self._skill_conversation_id_factory.delete_conversation_reference(
+            skill_conversation_id
+        )
 
         # Retrieve again
-        deleted_conversation_reference = await self._skill_conversation_id_factory.get_skill_conversation_reference(skill_conversation_id)
+        deleted_conversation_reference = await self._skill_conversation_id_factory.get_skill_conversation_reference(
+            skill_conversation_id
+        )
 
         self.assertIsNotNone(retrieved_conversation_reference)
         self.assertIsNotNone(retrieved_conversation_reference.conversation_reference)
-        self.assertEqual(conversation_reference, retrieved_conversation_reference.conversation_reference)
+        self.assertEqual(
+            conversation_reference,
+            retrieved_conversation_reference.conversation_reference,
+        )
         self.assertIsNone(deleted_conversation_reference)
 
-    async def test_id_is_unique_each_time(
-        self
-    ):
+    async def test_id_is_unique_each_time(self):
         conversation_reference = self._build_conversation_reference()
 
         # Create skill conversation
         first_id = await self._skill_conversation_id_factory.create_skill_conversation_id(
-            options= SkillConversationIdFactoryOptions(
+            options=SkillConversationIdFactoryOptions(
                 activity=self._build_message_activity(conversation_reference),
                 bot_framework_skill=self._build_bot_framework_skill(),
                 from_bot_id=self._bot_id,
-                from_bot_oauth_scope=self._bot_id
+                from_bot_oauth_scope=self._bot_id,
             )
         )
 
         second_id = await self._skill_conversation_id_factory.create_skill_conversation_id(
-            options= SkillConversationIdFactoryOptions(
+            options=SkillConversationIdFactoryOptions(
                 activity=self._build_message_activity(conversation_reference),
                 bot_framework_skill=self._build_bot_framework_skill(),
                 from_bot_id=self._bot_id,
-                from_bot_oauth_scope=self._bot_id
+                from_bot_oauth_scope=self._bot_id,
             )
         )
 
         # Ensure that we get a different conversation_id each time we call create_skill_conversation_id
         self.assertNotEqual(first_id, second_id)
 
-    def _build_conversation_reference(
-        self
-    ) -> ConversationReference:
+    def _build_conversation_reference(self) -> ConversationReference:
         return ConversationReference(
             conversation=ConversationAccount(id=str(uuid())),
-            service_url=self.SERVICE_URL
+            service_url=self.SERVICE_URL,
         )
 
     def _build_message_activity(
-        self,
-        conversation_reference: ConversationReference
+        self, conversation_reference: ConversationReference
     ) -> Activity:
         if not conversation_reference:
             raise TypeError(str(conversation_reference))
@@ -102,11 +105,9 @@ class SkillConversationIdFactoryForTest(AsyncTestCase):
 
         return activity
 
-    def _build_bot_framework_skill(
-        self
-    ) -> BotFrameworkSkill:
+    def _build_bot_framework_skill(self) -> BotFrameworkSkill:
         return BotFrameworkSkill(
             app_id=self._application_id,
             id=self.SKILL_ID,
-            skill_endpoint=self.SERVICE_URL
+            skill_endpoint=self.SERVICE_URL,
         )

--- a/libraries/botbuilder-core/tests/skills/test_skill_conversation_id_factory.py
+++ b/libraries/botbuilder-core/tests/skills/test_skill_conversation_id_factory.py
@@ -1,36 +1,33 @@
+from uuid import uuid4 as uuid
+from aiounittest import AsyncTestCase
 from botbuilder.core import (
     MemoryStorage,
-)
-from botbuilder.core.skills import (
-    ConversationIdFactoryBase,
-    SkillConversationIdFactory,
-    BotFrameworkSkill,
-    SkillConversationIdFactoryOptions,
 )
 from botbuilder.schema import (
     Activity,
     ConversationAccount,
     ConversationReference,
 )
-from uuid import uuid4 as uuid
+from botbuilder.core.skills import (
+    BotFrameworkSkill,
+    SkillConversationIdFactory,
+    SkillConversationIdFactoryOptions,
+)
 
-class SkillConversationIdFactoryForTest(ConversationIdFactoryBase):
+class SkillConversationIdFactoryForTest(AsyncTestCase):
     SERVICE_URL = "http://testbot.com/api/messages"
     SKILL_ID = "skill"
 
-    def __init__(self):
-        self._skill_conversation_id_factory = SkillConversationIdFactory(MemoryStorage())
-        self._application_id = str(uuid())
-        self._bot_id = str(uuid())
-    
+    @classmethod
+    def setUpClass(cls):
+        cls._skill_conversation_id_factory = SkillConversationIdFactory(MemoryStorage())
+        cls._application_id = str(uuid())
+        cls._bot_id = str(uuid())
 
     async def test_skill_conversation_id_factory_happy_path(
         self
     ):
-        conversation_reference = ConversationReference(
-            conversation=ConversationAccount(str(uuid)),
-            service_url=self.SERVICE_URL
-        )
+        conversation_reference = self._build_conversation_reference()
 
         # Create skill conversation
         skill_conversation_id = await self._skill_conversation_id_factory.create_skill_conversation_id(
@@ -42,7 +39,56 @@ class SkillConversationIdFactoryForTest(ConversationIdFactoryBase):
             )
         )
 
+        self.assertFalse(skill_conversation_id == None, "Expected a valid skill conversation ID to be created")
 
+        # Retrieve skill conversation
+        retrieved_conversation_reference = await self._skill_conversation_id_factory.get_skill_conversation_reference(skill_conversation_id)
+
+        # Delete
+        await self._skill_conversation_id_factory.delete_conversation_reference(skill_conversation_id)
+
+        # Retrieve again
+        deleted_conversation_reference = await self._skill_conversation_id_factory.get_skill_conversation_reference(skill_conversation_id)
+
+        self.assertIsNotNone(retrieved_conversation_reference)
+        self.assertIsNotNone(retrieved_conversation_reference.conversation_reference)
+        self.assertEqual(conversation_reference, retrieved_conversation_reference.conversation_reference)
+        self.assertIsNone(deleted_conversation_reference)
+
+    async def test_id_is_unique_each_time(
+        self
+    ):
+        conversation_reference = self._build_conversation_reference()
+
+        # Create skill conversation
+        first_id = await self._skill_conversation_id_factory.create_skill_conversation_id(
+            options= SkillConversationIdFactoryOptions(
+                activity=self._build_message_activity(conversation_reference),
+                bot_framework_skill=self._build_bot_framework_skill(),
+                from_bot_id=self._bot_id,
+                from_bot_oauth_scope=self._bot_id
+            )
+        )
+
+        second_id = await self._skill_conversation_id_factory.create_skill_conversation_id(
+            options= SkillConversationIdFactoryOptions(
+                activity=self._build_message_activity(conversation_reference),
+                bot_framework_skill=self._build_bot_framework_skill(),
+                from_bot_id=self._bot_id,
+                from_bot_oauth_scope=self._bot_id
+            )
+        )
+
+        # Ensure that we get a different conversation_id each time we call create_skill_conversation_id
+        self.assertNotEqual(first_id, second_id)
+
+    def _build_conversation_reference(
+        self
+    ) -> ConversationReference:
+        return ConversationReference(
+            conversation=ConversationAccount(id=str(uuid())),
+            service_url=self.SERVICE_URL
+        )
 
     def _build_message_activity(
         self,

--- a/libraries/botbuilder-core/tests/skills/test_skill_conversation_id_factory.py
+++ b/libraries/botbuilder-core/tests/skills/test_skill_conversation_id_factory.py
@@ -1,0 +1,66 @@
+from botbuilder.core import (
+    MemoryStorage,
+)
+from botbuilder.core.skills import (
+    ConversationIdFactoryBase,
+    SkillConversationIdFactory,
+    BotFrameworkSkill,
+    SkillConversationIdFactoryOptions,
+)
+from botbuilder.schema import (
+    Activity,
+    ConversationAccount,
+    ConversationReference,
+)
+from uuid import uuid4 as uuid
+
+class SkillConversationIdFactoryForTest(ConversationIdFactoryBase):
+    SERVICE_URL = "http://testbot.com/api/messages"
+    SKILL_ID = "skill"
+
+    def __init__(self):
+        self._skill_conversation_id_factory = SkillConversationIdFactory(MemoryStorage())
+        self._application_id = str(uuid())
+        self._bot_id = str(uuid())
+    
+
+    async def test_skill_conversation_id_factory_happy_path(
+        self
+    ):
+        conversation_reference = ConversationReference(
+            conversation=ConversationAccount(str(uuid)),
+            service_url=self.SERVICE_URL
+        )
+
+        # Create skill conversation
+        skill_conversation_id = await self._skill_conversation_id_factory.create_skill_conversation_id(
+            options= SkillConversationIdFactoryOptions(
+                activity=self._build_message_activity(conversation_reference),
+                bot_framework_skill=self._build_bot_framework_skill,
+                from_bot_id=self._bot_id,
+                from_bot_oauth_scope=self._bot_id
+            )
+        )
+
+
+
+    def _build_message_activity(
+        self,
+        conversation_reference: ConversationReference
+    ) -> Activity:
+        if not conversation_reference:
+            raise TypeError(str(conversation_reference))
+
+        activity = Activity.create_message_activity()
+        activity.apply_conversation_reference(conversation_reference)
+
+        return activity
+
+    def _build_bot_framework_skill(
+        self
+    ) -> BotFrameworkSkill:
+        return BotFrameworkSkill(
+            app_id=self._application_id,
+            id=self.SKILL_ID,
+            skill_endpoint=""
+        )

--- a/libraries/botbuilder-core/tests/skills/test_skill_conversation_id_factory.py
+++ b/libraries/botbuilder-core/tests/skills/test_skill_conversation_id_factory.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
 from uuid import uuid4 as uuid
 from aiounittest import AsyncTestCase
 from botbuilder.core import MemoryStorage

--- a/libraries/botbuilder-core/tests/skills/test_skill_handler.py
+++ b/libraries/botbuilder-core/tests/skills/test_skill_handler.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
 import hashlib
 import json
 from datetime import datetime

--- a/libraries/botbuilder-core/tests/skills/test_skill_handler.py
+++ b/libraries/botbuilder-core/tests/skills/test_skill_handler.py
@@ -18,7 +18,13 @@ from botbuilder.core import (
     BotActionNotImplementedError,
     conversation_reference_extension,
 )
-from botbuilder.core.skills import ConversationIdFactoryBase, SkillHandler
+from botbuilder.core.skills import (
+    ConversationIdFactoryBase,
+    SkillHandler,
+    SkillConversationReference,
+    SkillConversationIdFactoryOptions,
+    BotFrameworkSkill,
+)
 from botbuilder.schema import (
     Activity,
     ActivityTypes,
@@ -37,6 +43,36 @@ from botbuilder.schema import (
 
 
 class ConversationIdFactoryForTest(ConversationIdFactoryBase):
+    def __init__(self):
+        self._conversation_refs: Dict[str, str] = {}
+
+    async def create_skill_conversation_id(  # pylint: disable=W0221
+        self, options: SkillConversationIdFactoryOptions
+    ) -> str:
+        conversation_reference = TurnContext.get_conversation_reference(options.activity)
+
+        key = hashlib.md5(
+            f"{conversation_reference.conversation.id}{conversation_reference.service_url}".encode()
+        ).hexdigest()
+
+        skill_conversation_reference = SkillConversationReference(
+            conversation_reference=conversation_reference,
+            oauth_scope=options.from_bot_oauth_scope
+        )
+
+        self._conversation_refs[key] = skill_conversation_reference
+
+        return key
+
+    async def get_skill_conversation_reference(
+        self, skill_conversation_id: str
+    ) -> SkillConversationReference:
+        return self._conversation_refs[skill_conversation_id]
+
+    async def delete_conversation_reference(self, skill_conversation_id: str):
+        pass
+
+class LegacyConversationIdFactoryForTest(ConversationIdFactoryBase):
     def __init__(self):
         self._conversation_refs: Dict[str, str] = {}
 
@@ -187,8 +223,21 @@ class TestSkillHandler(aiounittest.AsyncTestCase):
             conversation=ConversationAccount(id=str(uuid4())),
             service_url="http://testbot.com/api/messages",
         )
+        activity = Activity.create_message_activity()
+        activity.apply_conversation_reference(cls._conversation_reference)
+        skill = BotFrameworkSkill(
+            app_id=cls.skill_id,
+            id="skill",
+            skill_endpoint="http://testbot.com/api/messages"
+        )
+        cls._options = SkillConversationIdFactoryOptions(
+            from_bot_oauth_scope=cls.bot_id,
+            from_bot_id=cls.bot_id,
+            activity=activity,
+            bot_framework_skill=skill
+        )
 
-    def create_skill_handler_for_testing(self, adapter) -> SkillHandlerInstanceForTests:
+    def create_skill_handler_for_testing(self, adapter, factory: ConversationIdFactoryBase = None) -> SkillHandlerInstanceForTests:
         mock_bot = Mock()
         mock_bot.on_turn = MagicMock(return_value=Future())
         mock_bot.on_turn.return_value.set_result(Mock())
@@ -196,15 +245,55 @@ class TestSkillHandler(aiounittest.AsyncTestCase):
         return SkillHandlerInstanceForTests(
             adapter,
             mock_bot,
-            self._test_id_factory,
+            (factory or self._test_id_factory),
             Mock(),
             AuthenticationConfiguration(),
         )
 
-    async def test_on_send_to_conversation(self):
-        self._conversation_id = await self._test_id_factory.create_skill_conversation_id(
-            self._conversation_reference
+    async def test_legacy_conversation_id_factory(self):
+        mock_adapter = Mock()
+
+        legacy_factory = LegacyConversationIdFactoryForTest()
+        conversation_reference = ConversationReference(
+            conversation=ConversationAccount(id=str(uuid4())),
+            service_url="http://testbot.com/api/messages",
         )
+
+        conversation_id = await legacy_factory.create_skill_conversation_id(conversation_reference)
+
+        async def continue_conversation(
+            reference: ConversationReference,
+            callback: Callable,
+            bot_id: str = None,
+            claims_identity: ClaimsIdentity = None,
+            audience: str = None,
+        ):  # pylint: disable=unused-argument
+            # Invoke the callback created by the handler so we can assert the rest of the execution.
+            turn_context = TurnContext(
+                mock_adapter,
+                conversation_reference_extension.get_continuation_activity(
+                    conversation_reference
+                ),
+            )
+            await callback(turn_context)
+
+        async def send_activities(
+            context: TurnContext, activities: List[Activity]
+        ):  # pylint: disable=unused-argument
+            return [ResourceResponse(id="resourceId")]
+
+        mock_adapter.continue_conversation = continue_conversation
+        mock_adapter.send_activities = send_activities
+
+        activity = Activity.create_message_activity()
+        activity.apply_conversation_reference(conversation_reference)
+
+        sut = self.create_skill_handler_for_testing(mock_adapter, legacy_factory)
+        await sut.test_on_send_to_conversation(self._claims_identity, conversation_id, activity)
+
+    async def test_on_send_to_conversation(self):
+        conversation_id = await self._test_id_factory.create_skill_conversation_id(self._options)
+
         # python 3.7 doesn't support AsyncMock, change this when min ver is 3.8
         send_activities_called = False
 
@@ -260,7 +349,7 @@ class TestSkillHandler(aiounittest.AsyncTestCase):
                 sut = self.create_skill_handler_for_testing(mock_adapter)
 
                 resource_response = await sut.test_on_send_to_conversation(
-                    self._claims_identity, self._conversation_id, activity
+                    self._claims_identity, conversation_id, activity
                 )
 
                 if activity_type == ActivityTypes.message:
@@ -268,9 +357,7 @@ class TestSkillHandler(aiounittest.AsyncTestCase):
                     assert resource_response.id == "resourceId"
 
     async def test_forwarding_on_send_to_conversation(self):
-        self._conversation_id = await self._test_id_factory.create_skill_conversation_id(
-            self._conversation_reference
-        )
+        conversation_id = await self._test_id_factory.create_skill_conversation_id(self._options)
 
         resource_response_id = "rId"
 
@@ -298,16 +385,14 @@ class TestSkillHandler(aiounittest.AsyncTestCase):
         assert not activity.caller_id
 
         response = await sut.test_on_send_to_conversation(
-            self._claims_identity, self._conversation_id, activity
+            self._claims_identity, conversation_id, activity
         )
 
         assert response.id is resource_response_id
 
     async def test_on_reply_to_activity(self):
         resource_response_id = "resourceId"
-        self._conversation_id = await self._test_id_factory.create_skill_conversation_id(
-            self._conversation_reference
-        )
+        conversation_id = await self._test_id_factory.create_skill_conversation_id(self._options)
 
         types_to_test = [
             ActivityTypes.end_of_conversation,
@@ -334,7 +419,7 @@ class TestSkillHandler(aiounittest.AsyncTestCase):
                 )
 
                 resource_response = await sut.test_on_reply_to_activity(
-                    self._claims_identity, self._conversation_id, activity_id, activity
+                    self._claims_identity, conversation_id, activity_id, activity
                 )
 
                 # continue_conversation validation
@@ -372,9 +457,7 @@ class TestSkillHandler(aiounittest.AsyncTestCase):
                     mock_adapter.send_activities.assert_not_called()
 
     async def test_on_update_activity(self):
-        self._conversation_id = await self._test_id_factory.create_skill_conversation_id(
-            self._conversation_reference
-        )
+        conversation_id = await self._test_id_factory.create_skill_conversation_id(self._options)
         resource_response_id = "resourceId"
         called_continue = False
         called_update = False
@@ -424,7 +507,7 @@ class TestSkillHandler(aiounittest.AsyncTestCase):
 
         sut = self.create_skill_handler_for_testing(mock_adapter)
         resource_response = await sut.test_on_update_activity(
-            self._claims_identity, self._conversation_id, activity_id, activity
+            self._claims_identity, conversation_id, activity_id, activity
         )
 
         assert called_continue
@@ -432,9 +515,7 @@ class TestSkillHandler(aiounittest.AsyncTestCase):
         assert resource_response, resource_response_id
 
     async def test_on_delete_activity(self):
-        self._conversation_id = await self._test_id_factory.create_skill_conversation_id(
-            self._conversation_reference
-        )
+        conversation_id = await self._test_id_factory.create_skill_conversation_id(self._options)
 
         resource_response_id = "resourceId"
         called_continue = False
@@ -479,14 +560,14 @@ class TestSkillHandler(aiounittest.AsyncTestCase):
         sut = self.create_skill_handler_for_testing(mock_adapter)
 
         await sut.test_on_delete_activity(
-            self._claims_identity, self._conversation_id, activity_id
+            self._claims_identity, conversation_id, activity_id
         )
 
         assert called_continue
         assert called_delete
 
     async def test_on_get_activity_members(self):
-        self._conversation_id = ""
+        conversation_id = ""
 
         mock_adapter = Mock()
 
@@ -495,7 +576,7 @@ class TestSkillHandler(aiounittest.AsyncTestCase):
 
         with self.assertRaises(BotActionNotImplementedError):
             await sut.test_on_get_activity_members(
-                self._claims_identity, self._conversation_id, activity_id
+                self._claims_identity, conversation_id, activity_id
             )
 
     async def test_on_create_conversation(self):
@@ -510,7 +591,7 @@ class TestSkillHandler(aiounittest.AsyncTestCase):
             )
 
     async def test_on_get_conversations(self):
-        self._conversation_id = ""
+        conversation_id = ""
 
         mock_adapter = Mock()
 
@@ -518,11 +599,11 @@ class TestSkillHandler(aiounittest.AsyncTestCase):
 
         with self.assertRaises(BotActionNotImplementedError):
             await sut.test_on_get_conversations(
-                self._claims_identity, self._conversation_id
+                self._claims_identity, conversation_id
             )
 
     async def test_on_get_conversation_members(self):
-        self._conversation_id = ""
+        conversation_id = ""
 
         mock_adapter = Mock()
 
@@ -530,11 +611,11 @@ class TestSkillHandler(aiounittest.AsyncTestCase):
 
         with self.assertRaises(BotActionNotImplementedError):
             await sut.test_on_get_conversation_members(
-                self._claims_identity, self._conversation_id
+                self._claims_identity, conversation_id
             )
 
     async def test_on_get_conversation_paged_members(self):
-        self._conversation_id = ""
+        conversation_id = ""
 
         mock_adapter = Mock()
 
@@ -542,11 +623,11 @@ class TestSkillHandler(aiounittest.AsyncTestCase):
 
         with self.assertRaises(BotActionNotImplementedError):
             await sut.test_on_get_conversation_paged_members(
-                self._claims_identity, self._conversation_id
+                self._claims_identity, conversation_id
             )
 
     async def test_on_delete_conversation_member(self):
-        self._conversation_id = ""
+        conversation_id = ""
 
         mock_adapter = Mock()
 
@@ -555,11 +636,11 @@ class TestSkillHandler(aiounittest.AsyncTestCase):
 
         with self.assertRaises(BotActionNotImplementedError):
             await sut.test_on_delete_conversation_member(
-                self._claims_identity, self._conversation_id, member_id
+                self._claims_identity, conversation_id, member_id
             )
 
     async def test_on_send_conversation_history(self):
-        self._conversation_id = ""
+        conversation_id = ""
 
         mock_adapter = Mock()
 
@@ -568,11 +649,11 @@ class TestSkillHandler(aiounittest.AsyncTestCase):
 
         with self.assertRaises(BotActionNotImplementedError):
             await sut.test_on_send_conversation_history(
-                self._claims_identity, self._conversation_id, transcript
+                self._claims_identity, conversation_id, transcript
             )
 
     async def test_on_upload_attachment(self):
-        self._conversation_id = ""
+        conversation_id = ""
 
         mock_adapter = Mock()
 
@@ -581,7 +662,7 @@ class TestSkillHandler(aiounittest.AsyncTestCase):
 
         with self.assertRaises(BotActionNotImplementedError):
             await sut.test_on_upload_attachment(
-                self._claims_identity, self._conversation_id, attachment_data
+                self._claims_identity, conversation_id, attachment_data
             )
 
     async def test_event_activity(self):
@@ -601,9 +682,7 @@ class TestSkillHandler(aiounittest.AsyncTestCase):
         )
 
     async def __activity_callback_test(self, activity: Activity):
-        self._conversation_id = await self._test_id_factory.create_skill_conversation_id(
-            self._conversation_reference
-        )
+        conversation_id = await self._test_id_factory.create_skill_conversation_id(self._options)
 
         mock_adapter = Mock()
         mock_adapter.continue_conversation = MagicMock(return_value=Future())
@@ -617,7 +696,7 @@ class TestSkillHandler(aiounittest.AsyncTestCase):
         TurnContext.apply_conversation_reference(activity, self._conversation_reference)
 
         await sut.test_on_reply_to_activity(
-            self._claims_identity, self._conversation_id, activity_id, activity
+            self._claims_identity, conversation_id, activity_id, activity
         )
 
         args, kwargs = mock_adapter.continue_conversation.call_args_list[0]

--- a/libraries/botbuilder-core/tests/skills/test_skill_handler.py
+++ b/libraries/botbuilder-core/tests/skills/test_skill_handler.py
@@ -42,14 +42,18 @@ from botbuilder.schema import (
 )
 
 
-class ConversationIdFactoryForTest(ConversationIdFactoryBase):
+class ConversationIdFactoryForTest(
+    ConversationIdFactoryBase
+):  # pylint: disable=abstract-method
     def __init__(self):
         self._conversation_refs: Dict[str, str] = {}
 
     async def create_skill_conversation_id(  # pylint: disable=W0221
         self, options: SkillConversationIdFactoryOptions
     ) -> str:
-        conversation_reference = TurnContext.get_conversation_reference(options.activity)
+        conversation_reference = TurnContext.get_conversation_reference(
+            options.activity
+        )
 
         key = hashlib.md5(
             f"{conversation_reference.conversation.id}{conversation_reference.service_url}".encode()
@@ -57,7 +61,7 @@ class ConversationIdFactoryForTest(ConversationIdFactoryBase):
 
         skill_conversation_reference = SkillConversationReference(
             conversation_reference=conversation_reference,
-            oauth_scope=options.from_bot_oauth_scope
+            oauth_scope=options.from_bot_oauth_scope,
         )
 
         self._conversation_refs[key] = skill_conversation_reference
@@ -72,7 +76,10 @@ class ConversationIdFactoryForTest(ConversationIdFactoryBase):
     async def delete_conversation_reference(self, skill_conversation_id: str):
         pass
 
-class LegacyConversationIdFactoryForTest(ConversationIdFactoryBase):
+
+class LegacyConversationIdFactoryForTest(
+    ConversationIdFactoryBase
+):  # pylint: disable=abstract-method
     def __init__(self):
         self._conversation_refs: Dict[str, str] = {}
 
@@ -228,16 +235,18 @@ class TestSkillHandler(aiounittest.AsyncTestCase):
         skill = BotFrameworkSkill(
             app_id=cls.skill_id,
             id="skill",
-            skill_endpoint="http://testbot.com/api/messages"
+            skill_endpoint="http://testbot.com/api/messages",
         )
         cls._options = SkillConversationIdFactoryOptions(
             from_bot_oauth_scope=cls.bot_id,
             from_bot_id=cls.bot_id,
             activity=activity,
-            bot_framework_skill=skill
+            bot_framework_skill=skill,
         )
 
-    def create_skill_handler_for_testing(self, adapter, factory: ConversationIdFactoryBase = None) -> SkillHandlerInstanceForTests:
+    def create_skill_handler_for_testing(
+        self, adapter, factory: ConversationIdFactoryBase = None
+    ) -> SkillHandlerInstanceForTests:
         mock_bot = Mock()
         mock_bot.on_turn = MagicMock(return_value=Future())
         mock_bot.on_turn.return_value.set_result(Mock())
@@ -259,7 +268,9 @@ class TestSkillHandler(aiounittest.AsyncTestCase):
             service_url="http://testbot.com/api/messages",
         )
 
-        conversation_id = await legacy_factory.create_skill_conversation_id(conversation_reference)
+        conversation_id = await legacy_factory.create_skill_conversation_id(
+            conversation_reference
+        )
 
         async def continue_conversation(
             reference: ConversationReference,
@@ -289,10 +300,14 @@ class TestSkillHandler(aiounittest.AsyncTestCase):
         activity.apply_conversation_reference(conversation_reference)
 
         sut = self.create_skill_handler_for_testing(mock_adapter, legacy_factory)
-        await sut.test_on_send_to_conversation(self._claims_identity, conversation_id, activity)
+        await sut.test_on_send_to_conversation(
+            self._claims_identity, conversation_id, activity
+        )
 
     async def test_on_send_to_conversation(self):
-        conversation_id = await self._test_id_factory.create_skill_conversation_id(self._options)
+        conversation_id = await self._test_id_factory.create_skill_conversation_id(
+            self._options
+        )
 
         # python 3.7 doesn't support AsyncMock, change this when min ver is 3.8
         send_activities_called = False
@@ -357,7 +372,9 @@ class TestSkillHandler(aiounittest.AsyncTestCase):
                     assert resource_response.id == "resourceId"
 
     async def test_forwarding_on_send_to_conversation(self):
-        conversation_id = await self._test_id_factory.create_skill_conversation_id(self._options)
+        conversation_id = await self._test_id_factory.create_skill_conversation_id(
+            self._options
+        )
 
         resource_response_id = "rId"
 
@@ -392,7 +409,9 @@ class TestSkillHandler(aiounittest.AsyncTestCase):
 
     async def test_on_reply_to_activity(self):
         resource_response_id = "resourceId"
-        conversation_id = await self._test_id_factory.create_skill_conversation_id(self._options)
+        conversation_id = await self._test_id_factory.create_skill_conversation_id(
+            self._options
+        )
 
         types_to_test = [
             ActivityTypes.end_of_conversation,
@@ -457,7 +476,9 @@ class TestSkillHandler(aiounittest.AsyncTestCase):
                     mock_adapter.send_activities.assert_not_called()
 
     async def test_on_update_activity(self):
-        conversation_id = await self._test_id_factory.create_skill_conversation_id(self._options)
+        conversation_id = await self._test_id_factory.create_skill_conversation_id(
+            self._options
+        )
         resource_response_id = "resourceId"
         called_continue = False
         called_update = False
@@ -515,7 +536,9 @@ class TestSkillHandler(aiounittest.AsyncTestCase):
         assert resource_response, resource_response_id
 
     async def test_on_delete_activity(self):
-        conversation_id = await self._test_id_factory.create_skill_conversation_id(self._options)
+        conversation_id = await self._test_id_factory.create_skill_conversation_id(
+            self._options
+        )
 
         resource_response_id = "resourceId"
         called_continue = False
@@ -598,9 +621,7 @@ class TestSkillHandler(aiounittest.AsyncTestCase):
         sut = self.create_skill_handler_for_testing(mock_adapter)
 
         with self.assertRaises(BotActionNotImplementedError):
-            await sut.test_on_get_conversations(
-                self._claims_identity, conversation_id
-            )
+            await sut.test_on_get_conversations(self._claims_identity, conversation_id)
 
     async def test_on_get_conversation_members(self):
         conversation_id = ""
@@ -682,7 +703,9 @@ class TestSkillHandler(aiounittest.AsyncTestCase):
         )
 
     async def __activity_callback_test(self, activity: Activity):
-        conversation_id = await self._test_id_factory.create_skill_conversation_id(self._options)
+        conversation_id = await self._test_id_factory.create_skill_conversation_id(
+            self._options
+        )
 
         mock_adapter = Mock()
         mock_adapter.continue_conversation = MagicMock(return_value=Future())

--- a/libraries/botbuilder-dialogs/tests/test_skill_dialog.py
+++ b/libraries/botbuilder-dialogs/tests/test_skill_dialog.py
@@ -68,9 +68,9 @@ class SimpleConversationIdFactory(ConversationIdFactoryBase):
             )
         return key
 
-    async def get_conversation_reference(
+    async def get_skill_conversation_reference(
         self, skill_conversation_id: str
-    ) -> Union[SkillConversationReference, ConversationReference]:
+    ) -> SkillConversationReference:
         return self.conversation_refs[skill_conversation_id]
 
     async def delete_conversation_reference(self, skill_conversation_id: str):

--- a/libraries/botbuilder-dialogs/tests/test_skill_dialog.py
+++ b/libraries/botbuilder-dialogs/tests/test_skill_dialog.py
@@ -43,7 +43,9 @@ from botbuilder.dialogs import (
 )
 
 
-class SimpleConversationIdFactory(ConversationIdFactoryBase):
+class SimpleConversationIdFactory(
+    ConversationIdFactoryBase
+):  # pylint: disable=abstract-method
     def __init__(self):
         self.conversation_refs = {}
         self.create_count = 0

--- a/libraries/botbuilder-integration-aiohttp/tests/skills/test_skill_http_client.py
+++ b/libraries/botbuilder-integration-aiohttp/tests/skills/test_skill_http_client.py
@@ -49,7 +49,7 @@ class SimpleConversationIdFactory(ConversationIdFactoryBase):
         )
         return key
 
-    async def get_conversation_reference(
+    async def get_skill_conversation_reference(
         self, skill_conversation_id: str
     ) -> SkillConversationReference:
         return self._conversation_refs[skill_conversation_id]

--- a/libraries/botframework-connector/botframework/connector/auth/skill_validation.py
+++ b/libraries/botframework-connector/botframework/connector/auth/skill_validation.py
@@ -65,14 +65,14 @@ class SkillValidation:
         :param claims: A dict of claims.
         :return bool:
         """
-        if AuthenticationConstants.VERSION_CLAIM not in claims:
-            return False
-
         if (
             claims.get(AuthenticationConstants.APP_ID_CLAIM, None)
             == AuthenticationConstants.ANONYMOUS_SKILL_APP_ID
         ):
             return True
+
+        if AuthenticationConstants.VERSION_CLAIM not in claims:
+            return False
 
         audience = claims.get(AuthenticationConstants.AUDIENCE_CLAIM)
 

--- a/libraries/botframework-connector/tests/test_auth.py
+++ b/libraries/botframework-connector/tests/test_auth.py
@@ -59,7 +59,7 @@ class TestAuth:
 
     @pytest.mark.asyncio
     async def test_claims_validation(self):
-        claims: List[Dict] = []
+        claims: List[Dict] = {}
         default_auth_config = AuthenticationConfiguration()
 
         # No validator should pass.


### PR DESCRIPTION
Fixes # 1687

## Description
This PR introduces the [SkillConversationIdFactory](https://github.com/microsoft/botbuilder-dotnet/blob/main/libraries/Microsoft.Bot.Builder/Skills/SkillConversationIdFactory.cs#L17) class ported from DotNet, adding/updating the necessary functionality to support the new and legacy functionality to be backward compatible.
New unit tests were added as well as updating the existing ones to support the new functionality.

> **Note:** The class [ConversationIdFactoryBase](https://github.com/microsoft/botbuilder-python/blob/main/libraries/botbuilder-core/botbuilder/core/skills/conversation_id_factory.py#L11) and file name were not updated to maintain parity from DotNet ([SkillConversationIdFactoryBase](https://github.com/microsoft/botbuilder-dotnet/blob/main/libraries/Microsoft.Bot.Builder/Skills/SkillConversationIdFactoryBase.cs#L14)) because it will be a breaking change for anyone using this class.
> **We created the issue #SW18 to keep track of this change.**

## Specific Changes
- Added the new `SkillConversationIdFactory` class that inherits from `ConversationIdFactoryBase` with the new functionality.
- Updated the `ConversationIdFactoryBase` class to deprecate the `get_conversation_reference` and introduce the `get_skill_conversation_reference` method.
  - `@abstractmethod` decorator were removed, so the user is not warned to implement the new method and the legacy one (Addressing a breaking change), the usage of the decorator were removed from the rest of the methods to maintain consistency, if any method is not implemented from the Base class it will throw a `NotImplemented` error.
- Updated the `SkillHandler` class to support the new `get_skill_conversation_reference` method and be backward compatible to the legacy one
  - Also a default Logger were added when not provided to enable the use of the logger functionality inside the class (ported from DotNet).
- Added new unit tests in the `test_skill_conversation_id_factory.py` file to support the new SkillConversationIdFactory class.
- Updated `test_skill_dialog.py` and `test_skill_http_client.py` files to support the new SkillConversationIdFactory functionality instead of the legacy one.
- Updated `test_skill_handler.py` to replace all the tests that were using the legacy functionality to start using the new one.
  - For legacy functionality a new test `test_legacy_conversation_id_factory` were ported from DotNet.

## Testing
The following images show the test passing locally and in the CI pipelines.
![image](https://user-images.githubusercontent.com/62260472/120383155-e71d4600-c2fa-11eb-9511-ef5d93e61cc0.png)