### PR TITLE
Fix get_skill_conversation_reference in skill_handler

### DIFF
--- a/libraries/botbuilder-core/botbuilder/core/skills/skill_handler.py
+++ b/libraries/botbuilder-core/botbuilder/core/skills/skill_handler.py
@@ -200,14 +200,17 @@ class SkillHandler(ChannelServiceHandler):
                 conversation_id
             )
 
-            skill_conversation_reference: SkillConversationReference = SkillConversationReference(
-                conversation_reference=conversation_reference,
-                oauth_scope=(
-                    GovernmentConstants.TO_CHANNEL_FROM_BOT_OAUTH_SCOPE
-                    if self._channel_provider and self._channel_provider.is_government()
-                    else AuthenticationConstants.TO_CHANNEL_FROM_BOT_OAUTH_SCOPE
-                ),
-            )
+            if isinstance(conversation_reference, SkillConversationReference):
+                skill_conversation_reference: SkillConversationReference = conversation_reference
+            else:
+                skill_conversation_reference: SkillConversationReference = SkillConversationReference(
+                    conversation_reference=conversation_reference,
+                    oauth_scope=(
+                        GovernmentConstants.TO_CHANNEL_FROM_BOT_OAUTH_SCOPE
+                        if self._channel_provider and self._channel_provider.is_government()
+                        else AuthenticationConstants.TO_CHANNEL_FROM_BOT_OAUTH_SCOPE
+                    ),
+                )
 
         if not skill_conversation_reference:
             raise KeyError("SkillConversationReference not found")

--- a/libraries/botbuilder-core/botbuilder/core/skills/skill_handler.py
+++ b/libraries/botbuilder-core/botbuilder/core/skills/skill_handler.py
@@ -207,7 +207,8 @@ class SkillHandler(ChannelServiceHandler):
                     conversation_reference=conversation_reference,
                     oauth_scope=(
                         GovernmentConstants.TO_CHANNEL_FROM_BOT_OAUTH_SCOPE
-                        if self._channel_provider and self._channel_provider.is_government()
+                        if self._channel_provider
+                        and self._channel_provider.is_government()
                         else AuthenticationConstants.TO_CHANNEL_FROM_BOT_OAUTH_SCOPE
                     ),
                 )


### PR DESCRIPTION
#minor

## Description
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
This PR adds a validation in `skill_handler.py` for the `get_skill_conversation_reference` method.
This missing validation was causing an error in bots with a custom `SkillConversationIdFactory` class, building the reference in the `get_conversation_reference` method, and being over nested.

This issue was introduced in PR# 1691, for ISSUE# 1687.

With the change in this PR, the users can still use their previous implementation of the `SkillConversationIdFactory`.

The bots used to test are the [WaterfallHostBot Python](https://github.com/microsoft/BotFramework-FunctionalTests/tree/main/Bots/Python/Consumers/CodeFirst/WaterfallHostBot) and [WaterfallSkillBot Python](https://github.com/microsoft/BotFramework-FunctionalTests/tree/main/Bots/Python/Skills/CodeFirst/WaterfallSkillBot) from the [BotFramework-FunctionalTests](https://github.com/microsoft/BotFramework-FunctionalTests/) repo.

The BotBuilder version used for all the packages is the most recent as of today from the main branch of this repo.

## Specific Changes
<!-- Please list the changes in a concise manner. -->

  - Added an if to check if the conversation_reference is already a SkillConversationReference instance and return it.

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->
Before the change the Host Bot throws the following errors in the step shown, using the current latest version of main from botbuilder-core.
![image](https://user-images.githubusercontent.com/38112957/122456627-2945b900-cf84-11eb-93e6-f4b99d0bd0ea.png)
![image](https://user-images.githubusercontent.com/38112957/122456518-0f0bdb00-cf84-11eb-9505-bfbd657232cb.png)

After applying the changes in this PR, the conversation works as expected.
![image](https://user-images.githubusercontent.com/38112957/122456681-382c6b80-cf84-11eb-93d4-9d63b0daf69b.png)
